### PR TITLE
add sample zuul routes prod configuration

### DIFF
--- a/central-config/gateway-dev.yml
+++ b/central-config/gateway-dev.yml
@@ -1,0 +1,2 @@
+# Gateway "dev" configuration
+

--- a/central-config/gateway-prod.yml
+++ b/central-config/gateway-prod.yml
@@ -1,0 +1,13 @@
+# Gateway "prod" configuration
+# In prod profile, microservices are not automatically added to the gateway's routes
+
+zuul:
+    routes:
+        # sample microservice route
+        route1:
+            path: /app1/**
+            serviceId: app1
+        # sample regular API route (http://petstore.swagger.io)
+        #route2:
+        #    path: /petstore/**
+        #    url: http://petstore.swagger.io/v2/

--- a/central-config/gateway.yml
+++ b/central-config/gateway.yml
@@ -1,3 +1,3 @@
 # Used on the gateway's startup to check the config server status
 configserver:
-    status: ${spring.cloud.config.uri} (OK)
+    status: ${spring.cloud.config.uri}/${spring.cloud.config.name}/${spring.cloud.config.profile}/${spring.cloud.config.label}


### PR DESCRIPTION
This is mostly as a way to guide the users on how to use the config server.
@jdubois Tell me if you don't like it or would like something added.
Next I would like to add a section to the README on how to change gateway routes from the config server.