### PR TITLE
allow passing the profile to the docker image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV JAVA_VERSION_MAJOR=8 \
     JAVA_PACKAGE=jdk \
     JAVA_HOME=/opt/jdk \
     PATH=${PATH}:/opt/jdk/bin \
-    LANG=C.UTF-8
+    LANG=C.UTF-8 \
+    SPRING_PROFILES=prod
 
 # do all in one step : install java
 RUN apk upgrade --update && \
@@ -76,4 +77,4 @@ RUN cd /code/ && \
 RUN bash -c 'touch /jhipster-registry.jar'
 EXPOSE 8761
 VOLUME /tmp
-CMD ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/jhipster-registry.jar"]
+CMD ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/jhipster-registry.jar","--spring.profiles.active=${SPRING_PROFILES}"]


### PR DESCRIPTION
Here is a sample docker-compose file to demonstrate the feature:
```
jhipster-registry:
  container_name: jhipster-registry
  build: ./jhipster-registry/
  environment:
    - "SPRING_PROFILES=dev,native"
  ports:
    - "8761:8761"
  volumes:
    - ./central-config:/central-config
```
I have set the default to prod. I have done it because since #8 we use the `central-config` folder in  https://github.com/jhipster/jhipster-registry as the config source. Also I read somewhere that the native profile was bad because it could not "cache" the configuration and was forced to read it from disk every time it needed it. I'm not sure if it still does that but anyway the git config is the way to go.