### PR TITLE
Add build step to use dev profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,20 @@
                 <!-- log configuration -->
                 <logback.loglevel>DEBUG</logback.loglevel>
             </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-maven-plugin</artifactId>
+                        <configuration>
+                            <executable>true</executable>
+                            <arguments>
+                                <argument>--spring.profiles.active=dev,native</argument>
+                            </arguments>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>prod</id>


### PR DESCRIPTION
#37 Fixes the build to allow using the `dev` profile when running locally.
