### PR TITLE
[develop] Upgrade gulp-angular-templatecache from 1.8.0 to 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "generator-jhipster": "3.4.0",
     "gulp": "3.9.1",
     "gulp-angular-filesort": "1.1.1",
-    "gulp-angular-templatecache": "1.8.0",
+    "gulp-angular-templatecache": "1.9.0",
     "gulp-autoprefixer": "3.1.0",
     "gulp-changed": "1.3.0",
     "gulp-cssnano": "2.1.2",


### PR DESCRIPTION
Fix https://github.com/jhipster/jhipster-registry/issues/61