### PR TITLE
Updated app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -3,8 +3,11 @@
   "description": "This is the JHipster registry service, based on Spring Cloud Netflix, Eureka and Spring Cloud Config.",
   "env": {
     "JHIPSTER_PASSWORD": {
-      "description": "Admin password for the registry (used to login after clicking 'View App').",
+      "description": "Admin password for the registry (used to login after clicking 'View App'). Must be at least 5 characters.",
       "required": "true"
     }
-  }
+  },
+  "buildpacks": [
+    {"url": "heroku/java"}
+  ]
 }


### PR DESCRIPTION
Set buildpack explicitly to avoid this warning:

```
-----> Warning: Multiple default buildpacks reported the ability to handle this app. The first buildpack in the list below will be used.
```

Also improve password description, as it must be at least 5 characters. 