### PR TITLE
Fix autocomplete for services in configuration screen

### DIFF
--- a/src/main/webapp/app/config/config.controller.js
+++ b/src/main/webapp/app/config/config.controller.js
@@ -40,7 +40,9 @@
             ApplicationsService.get().$promise.then(function(data) {
                 vm.applicationList = ["application"];
                 data.applications.forEach(function (application) {
-                    vm.applicationList.push(application.name.toLowerCase())
+                    var instanceId = application.instances[0].instanceId;
+                    var applicationName = instanceId.indexOf(':') == -1 ? application.name.toLowerCase() : instanceId.substr(0, instanceId.indexOf(':'));
+                    vm.applicationList.push(applicationName);
                 });
             });
         }


### PR DESCRIPTION
There was an issue when application name contained upper case characters, they were converted to lowercase and it didn't display the configuration file.
![screenshot from 2016-09-06 10 07 00](https://cloud.githubusercontent.com/assets/11872070/18266583/a8ca49bc-741b-11e6-903a-291abea29fa5.png)
