### PR TITLE
fix autocomplete for services in configuration screen

### DIFF
--- a/src/main/webapp/app/config/config.controller.js
+++ b/src/main/webapp/app/config/config.controller.js
@@ -40,7 +40,9 @@
             ApplicationsService.get().$promise.then(function(data) {
                 vm.applicationList = ["application"];
                 data.applications.forEach(function (application) {
-                    vm.applicationList.push(application.name.toLowerCase())
+                    var instanceId = application.instances[0].instanceId;
+                    var applicationName = instanceId.indexOf(':') == -1 ? application.name.toLowerCase() : instanceId.substr(0, instanceId.indexOf(':'));
+                    vm.applicationList.push(applicationName);
                 });
             });
         }


### PR DESCRIPTION
Application name appeared in lowercase even with uppercase characters. Couldn't display configuration file with a wrong application name.
![screenshot from 2016-09-06 10 07 00](https://cloud.githubusercontent.com/assets/11872070/18267358/082c2b02-741f-11e6-8404-47cecbc945a2.png)
