### PR TITLE
fix ssh git setup example

### DIFF
--- a/src/main/webapp/app/ssh/ssh.html
+++ b/src/main/webapp/app/ssh/ssh.html
@@ -52,7 +52,8 @@
         - ./ssh/:/root/.ssh/
       environment:
         - SPRING_PROFILES_ACTIVE=prod
-        - GIT_URI=ssh:git@github.com:jhipster/test-registry.git
+        - GIT_URI=git@github.com:jhipster/jhipster-registry.git
+        - GIT_SEARCH_PATHS=central-config
       ports:
         - 8761:8761
         </div>


### PR DESCRIPTION
When the GIT_URI begins with `ssh:` as in the example, I get `com.jcraft.jsch.JSchException: Auth fail` even if the repository is public.

I also updated the example to use an actual example repository and folder path.