### PR TITLE
[develop] Change enable-self-preservation to false

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.github.jhipster</groupId>
     <artifactId>jhipster-registry</artifactId>
-    <version>2.4.0</version>
+    <version>2.5.0</version>
     <packaging>war</packaging>
     <name>JHipster Registry</name>
     <description>JHipster service registry, made with Netflix Eureka and Spring Cloud Config</description>

--- a/src/main/java/io/github/jhipster/registry/config/WebConfigurer.java
+++ b/src/main/java/io/github/jhipster/registry/config/WebConfigurer.java
@@ -11,8 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.*;
-import org.springframework.boot.context.embedded.tomcat.TomcatContextCustomizer;
-import org.springframework.boot.context.embedded.tomcat.TomcatEmbeddedServletContainerFactory;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
@@ -51,7 +49,7 @@ public class WebConfigurer implements ServletContextInitializer, EmbeddedServlet
     }
 
     /**
-     * Customize the Tomcat engine: Mime types, the document root, the cache.
+     * Set up Mime types and, if needed, set the document root.
      */
     @Override
     public void customize(ConfigurableEmbeddedServletContainer container) {

--- a/src/main/resources/config/application-dev.yml
+++ b/src/main/resources/config/application-dev.yml
@@ -17,7 +17,9 @@ eureka:
         appname: registry
         prefer-ip-address: true
     server:
-        enable-self-preservation: true
+        # see discussion about enable-self-preservation:
+        # https://github.com/jhipster/generator-jhipster/issues/3654
+        enable-self-preservation: false
     client:
         fetch-registry: false
         register-with-eureka: false

--- a/src/main/resources/config/application-peer1.yml
+++ b/src/main/resources/config/application-peer1.yml
@@ -28,7 +28,9 @@ eureka:
     instance:
         hostname: eureka-peer-1
     server:
-        enable-self-preservation: true
+        # see discussion about enable-self-preservation:
+        # https://github.com/jhipster/generator-jhipster/issues/3654
+        enable-self-preservation: false
         registry-sync-retry-wait-ms: 500
         a-sgcache-expiry-timeout-ms: 60000
         eviction-interval-timer-in-ms: 30000

--- a/src/main/resources/config/application-peer2.yml
+++ b/src/main/resources/config/application-peer2.yml
@@ -28,7 +28,9 @@ eureka:
     instance:
         hostname: eureka-peer-2
     server:
-        enable-self-preservation: true
+        # see discussion about enable-self-preservation:
+        # https://github.com/jhipster/generator-jhipster/issues/3654
+        enable-self-preservation: false
         registry-sync-retry-wait-ms: 500
         a-sgcache-expiry-timeout-ms: 60000
         eviction-interval-timer-in-ms: 30000

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -17,7 +17,9 @@ eureka:
         appname: registry
         prefer-ip-address: true
     server:
-        enable-self-preservation: true
+        # see discussion about enable-self-preservation:
+        # https://github.com/jhipster/generator-jhipster/issues/3654
+        enable-self-preservation: false
     client:
         fetch-registry: false
         register-with-eureka: false


### PR DESCRIPTION
I'm changing the `eureka.server.enable-self-preservation` to `false`, so the evict task will unregister the service properly.

Fix https://github.com/jhipster/generator-jhipster/issues/3654

Note: I did a rebase on the develop branch too, so there are additional commits