### PR TITLE
Add refresh timer, memorizes choices and avoid some inconsistencies

### DIFF
--- a/src/main/java/io/github/jhipster/registry/service/ZuulUpdaterService.java
+++ b/src/main/java/io/github/jhipster/registry/service/ZuulUpdaterService.java
@@ -60,12 +60,14 @@ public class ZuulUpdaterService {
                     null, url, zuulProperties.isStripPrefix(), zuulProperties.getRetryable(), null,
                     instanceInfos.getStatus().toString());
 
-                if (zuulProperties.getRoutes().containsKey(instanceId) &&
-                    !zuulProperties.getRoutes().get(instanceId).getUrl().equals(url)) {
-                    log.debug("Updating instance '{}' with new URL: {}", instanceId, url);
-                    zuulProperties.getRoutes().put(instanceId, route);
-                    isDirty = true;
+                if (zuulProperties.getRoutes().containsKey(instanceId)) {
+                    log.debug("Instance '{}' already registered", instanceId);
+                    if (!zuulProperties.getRoutes().get(instanceId).getUrl().equals(url)) {
 
+                        log.debug("Updating instance '{}' with new URL: {}", instanceId, url);
+                        zuulProperties.getRoutes().put(instanceId, route);
+                        isDirty = true;
+                    }
                 } else {
                     log.debug("Adding instance '{}' with URL: {}", instanceId, url);
                     zuulProperties.getRoutes().put(instanceId, route);

--- a/src/main/webapp/app/admin/configuration/configuration.component.ts
+++ b/src/main/webapp/app/admin/configuration/configuration.component.ts
@@ -56,11 +56,15 @@ export class JhiConfigurationComponent implements OnInit, OnDestroy {
                         this.configKeys.push(Object.keys(config.properties));
                     }
                 }
+            }, (error) => {
+                this.routesService.routeDown(this.activeRoute);
             });
 
             this.configurationService.getInstanceEnv(this.activeRoute).subscribe((configuration) => {
                 this.allConfiguration = configuration;
             });
+        } else {
+            this.routesService.routeDown(this.activeRoute);
         }
     }
 

--- a/src/main/webapp/app/admin/health/health.component.ts
+++ b/src/main/webapp/app/admin/health/health.component.ts
@@ -49,6 +49,8 @@ export class JhiHealthCheckComponent implements OnInit, OnDestroy {
                     }
                 }
             });
+        } else {
+            this.routesService.routeDown(this.activeRoute);
         }
     }
 

--- a/src/main/webapp/app/admin/logs/logs.component.html
+++ b/src/main/webapp/app/admin/logs/logs.component.html
@@ -21,11 +21,11 @@
         <tr *ngFor="let logger of (loggers | pureFilter:filter:'name' | orderBy:orderProp:reverse)">
             <td><small>{{logger.name | slice:0:140}}</small></td>
             <td>
-                <button (click)="changeLevel(logger.name, 'TRACE')" [ngClass]="(logger.level=='TRACE') ? 'btn-danger' : 'btn-secondary'" class="btn btn-sm">TRACE</button>
-                <button (click)="changeLevel(logger.name, 'DEBUG')" [ngClass]="(logger.level=='DEBUG') ? 'btn-warning' : 'btn-secondary'" class="btn btn-sm">DEBUG</button>
+                <button (click)="changeLevel(logger.name, 'TRACE')" [ngClass]="(logger.level=='TRACE') ? 'btn-primary' : 'btn-secondary'" class="btn btn-sm">TRACE</button>
+                <button (click)="changeLevel(logger.name, 'DEBUG')" [ngClass]="(logger.level=='DEBUG') ? 'btn-success' : 'btn-secondary'" class="btn btn-sm">DEBUG</button>
                 <button (click)="changeLevel(logger.name, 'INFO')" [ngClass]="(logger.level=='INFO') ? 'btn-info' : 'btn-secondary'" class="btn btn-sm">INFO</button>
-                <button (click)="changeLevel(logger.name, 'WARN')" [ngClass]="(logger.level=='WARN') ? 'btn-success' : 'btn-secondary'" class="btn btn-sm">WARN</button>
-                <button (click)="changeLevel(logger.name, 'ERROR')" [ngClass]="(logger.level=='ERROR') ? 'btn-primary' : 'btn-secondary'" class="btn btn-sm">ERROR</button>
+                <button (click)="changeLevel(logger.name, 'WARN')" [ngClass]="(logger.level=='WARN') ? 'btn-warning' : 'btn-secondary'" class="btn btn-sm">WARN</button>
+                <button (click)="changeLevel(logger.name, 'ERROR')" [ngClass]="(logger.level=='ERROR') ? 'btn-danger' : 'btn-secondary'" class="btn btn-sm">ERROR</button>
             </td>
         </tr>
     </table>

--- a/src/main/webapp/app/admin/logs/logs.component.ts
+++ b/src/main/webapp/app/admin/logs/logs.component.ts
@@ -65,6 +65,8 @@ export class LogsComponent implements OnInit, OnDestroy {
                     }
                 }
             });
+        } else {
+            this.routesService.routeDown(this.activeRoute);
         }
     }
 

--- a/src/main/webapp/app/admin/metrics/metrics.component.html
+++ b/src/main/webapp/app/admin/metrics/metrics.component.html
@@ -178,7 +178,7 @@
             </tbody>
         </table>
     </div>
-    
+
     <h3 *ngIf="metrics.gauges && metrics.gauges['HikariPool-1.pool.TotalConnections'] && metrics.gauges['HikariPool-1.pool.TotalConnections'].value > 0">DataSource statistics (time in millisecond)</h3>
     <div class="table-responsive" *ngIf="!updatingMetrics && metrics.gauges && metrics.gauges['HikariPool-1.pool.TotalConnections'] && metrics.gauges['HikariPool-1.pool.TotalConnections'].value > 0">
         <table class="table table-striped">

--- a/src/main/webapp/app/admin/metrics/metrics.component.ts
+++ b/src/main/webapp/app/admin/metrics/metrics.component.ts
@@ -74,6 +74,8 @@ export class JhiMetricsMonitoringComponent implements OnInit {
                     }
                 }
             });
+        } else {
+            this.routesService.routeDown(this.activeRoute);
         }
     }
 

--- a/src/main/webapp/app/shared/auth/state-storage.service.ts
+++ b/src/main/webapp/app/shared/auth/state-storage.service.ts
@@ -46,19 +46,4 @@ export class StateStorageService {
         this.$sessionStorage.store('destinationState', destinationInfo);
     }
 
-    getSelectedInstance() {
-        return this.$sessionStorage.retrieve('instanceId');
-    }
-
-    storeSelectedInstance(instance) {
-        this.$sessionStorage.store('instanceId', instance);
-    }
-
-    getSelectedRefreshTime(): number {
-        return this.$sessionStorage.retrieve('refreshTime');
-    }
-
-    storeSelectedRefreshTime(time: number) {
-        this.$sessionStorage.store('refreshTime', time);
-    }
 }

--- a/src/main/webapp/app/shared/auth/state-storage.service.ts
+++ b/src/main/webapp/app/shared/auth/state-storage.service.ts
@@ -45,4 +45,20 @@ export class StateStorageService {
         };
         this.$sessionStorage.store('destinationState', destinationInfo);
     }
+
+    getSelectedInstance() {
+        return this.$sessionStorage.retrieve('instanceId');
+    }
+
+    storeSelectedInstance(instance) {
+        this.$sessionStorage.store('instanceId', instance);
+    }
+
+    getSelectedRefreshTime(): number {
+        return this.$sessionStorage.retrieve('refreshTime');
+    }
+
+    storeSelectedRefreshTime(time: number) {
+        this.$sessionStorage.store('refreshTime', time);
+    }
 }

--- a/src/main/webapp/app/shared/routes/route-selector.component.html
+++ b/src/main/webapp/app/shared/routes/route-selector.component.html
@@ -1,6 +1,6 @@
 <div class="route-selector col-md-10 d-inline-flex" *ngIf="routes">
 
-    <div ngbDropdown id="dropInstances" #dropId="ngbDropdown">
+    <div ngbDropdown #dropId="ngbDropdown">
         <button class="btn btn-outline-primary" id="sortMenu" ngbDropdownToggle [innerHTML]="getActiveRoute()"></button>
         <div class="dropdown-menu" aria-labelledby="sortMenu" aria-expanded="true" (click)="$event.stopPropagation()">
             <p class="d-flex">
@@ -21,7 +21,7 @@
         </div>
     </div>
 
-    <div ngbDropdown id="dropRefresh" #dropRefreshId="ngbDropdown">
+    <div ngbDropdown>
         <button class="btn btn-outline-primary" [ngClass]="classTime()" id="refreshMenu" ngbDropdownToggle [innerHTML]="'&nbsp; '+getActiveRefreshTime()"></button>
         <div class="dropdown-menu" aria-labelledby="refreshMenu" aria-expanded="true">
             <span class="dropdown-header">Refresh times (in seconds)</span>

--- a/src/main/webapp/app/shared/routes/route-selector.component.html
+++ b/src/main/webapp/app/shared/routes/route-selector.component.html
@@ -1,6 +1,6 @@
-<div class="route-selector col-md-7" *ngIf="routes">
+<div class="route-selector col-md-10 d-inline-flex" *ngIf="routes">
 
-    <div ngbDropdown #dropId="ngbDropdown">
+    <div ngbDropdown id="dropInstances" #dropId="ngbDropdown">
         <button class="btn btn-outline-primary" id="sortMenu" ngbDropdownToggle [innerHTML]="getActiveRoute()"></button>
         <div class="dropdown-menu" aria-labelledby="sortMenu" aria-expanded="true" (click)="$event.stopPropagation()">
             <p class="d-flex">
@@ -21,5 +21,17 @@
         </div>
     </div>
 
-    <p *ngIf="updatingRoutes">Loading...</p>
+    <div ngbDropdown id="dropRefresh" #dropRefreshId="ngbDropdown">
+        <button class="btn btn-outline-primary" [ngClass]="classTime()" id="refreshMenu" ngbDropdownToggle [innerHTML]="'&nbsp; '+getActiveRefreshTime()"></button>
+        <div class="dropdown-menu" aria-labelledby="refreshMenu" aria-expanded="true">
+            <span class="dropdown-header">Refresh times (in seconds)</span>
+            <div *ngFor="let time of refreshTimes">
+                <button class="dropdown-item" (click)="setActiveRefreshTime(time);" [ngClass]="stateTime(time)">
+                    <span class="name">{{time}}</span>
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <p *ngIf="updatingRoutes && (!routes || routes.length == 0)">Loading...</p>
 </div>

--- a/src/main/webapp/app/shared/routes/route-selector.component.html
+++ b/src/main/webapp/app/shared/routes/route-selector.component.html
@@ -1,10 +1,10 @@
 <div class="route-selector col-md-10 d-inline-flex" *ngIf="routes">
 
-    <div ngbDropdown #dropId="ngbDropdown">
+    <div class="dropdown" ngbDropdown #dropId="ngbDropdown">
         <button class="btn btn-outline-primary" id="sortMenu" ngbDropdownToggle [innerHTML]="getActiveRoute()"></button>
         <div class="dropdown-menu" aria-labelledby="sortMenu" aria-expanded="true" (click)="$event.stopPropagation()">
             <p class="d-flex">
-                <input type="search" class="form-control d-flex" placeholder="Search an application..."
+                <input type="search" class="form-control d-flex search" placeholder="Search an application..."
                        [(ngModel)]="searchedInstance" (click)="$event.stopPropagation()" (input)="searchByAppName($event)">
             </p>
             <div *ngFor="let app of routes | groupBy : 'appName'">
@@ -21,7 +21,7 @@
         </div>
     </div>
 
-    <div ngbDropdown>
+    <div class="dropdown" ngbDropdown>
         <button class="btn btn-outline-primary" [ngClass]="classTime()" id="refreshMenu" ngbDropdownToggle [innerHTML]="'&nbsp; '+getActiveRefreshTime()"></button>
         <div class="dropdown-menu" aria-labelledby="refreshMenu" aria-expanded="true">
             <span class="dropdown-header">Refresh times (in seconds)</span>

--- a/src/main/webapp/app/shared/routes/route-selector.component.scss
+++ b/src/main/webapp/app/shared/routes/route-selector.component.scss
@@ -6,13 +6,13 @@ Route selector styles
     margin-top: 1%;
     margin-bottom: 2%;
     padding-left: 0;
-    input[type="search"] {
-        margin: auto 10px;
-    }
-    div {
+    .dropdown {
         margin-right: 10px;
         .dropdown-menu {
             border-color: darkgrey;
+            .search {
+                margin: auto 10px;
+            }
             .dropdown-item { /* routes names */
                 margin-right: 0.5rem;
                 word-break: break-all;

--- a/src/main/webapp/app/shared/routes/route-selector.component.scss
+++ b/src/main/webapp/app/shared/routes/route-selector.component.scss
@@ -9,6 +9,9 @@ Route selector styles
     input[type="search"] {
         margin: auto 10px;
     }
+    #dropRefresh{
+        margin-left: 10px;
+    }
     .dropdown-menu {
         border-color: darkgrey;
         .dropdown-item { /* routes names */

--- a/src/main/webapp/app/shared/routes/route-selector.component.scss
+++ b/src/main/webapp/app/shared/routes/route-selector.component.scss
@@ -9,30 +9,30 @@ Route selector styles
     input[type="search"] {
         margin: auto 10px;
     }
-    #dropRefresh{
-        margin-left: 10px;
-    }
-    .dropdown-menu {
-        border-color: darkgrey;
-        .dropdown-item { /* routes names */
-            margin-right: 0.5rem;
-            word-break: break-all;
-            display: block;
-            display: -webkit-flex;
-            justify-content: space-between;
-            &:hover {
-                color: #fff;
-                background-color: #80bed8;
-            }
-            &:active {
-                color: #fff;
-                background-color: #0275d8;
-            }
-            .badge { /** vertically center badges */
-                margin: auto 0;
-            }
-            &.disabled { /** disable DOWN instances **/
-                pointer-events: none;
+    div {
+        margin-right: 10px;
+        .dropdown-menu {
+            border-color: darkgrey;
+            .dropdown-item { /* routes names */
+                margin-right: 0.5rem;
+                word-break: break-all;
+                display: block;
+                display: -webkit-flex;
+                justify-content: space-between;
+                &:hover {
+                    color: #fff;
+                    background-color: #80bed8;
+                }
+                &:active {
+                    color: #fff;
+                    background-color: #0275d8;
+                }
+                .badge { /** vertically center badges */
+                    margin: auto 0;
+                }
+                &.disabled { /** disable DOWN instances **/
+                    pointer-events: none;
+                }
             }
         }
     }

--- a/src/main/webapp/app/shared/routes/route-selector.component.ts
+++ b/src/main/webapp/app/shared/routes/route-selector.component.ts
@@ -4,6 +4,8 @@ import { Subscription } from 'rxjs/Subscription';
 import { JhiRoutesService } from './routes.service';
 import { Route } from './route.model';
 import { NgbDropdown } from '@ng-bootstrap/ng-bootstrap';
+import { Observable } from 'rxjs/Observable';
+import { StateStorageService } from '../auth/state-storage.service';
 
 @Component({
     selector: 'jhi-route-selector',
@@ -22,23 +24,39 @@ export class JhiRouteSelectorComponent implements OnInit, OnDestroy {
     routeReloadSubscription: Subscription;
     routeDownSubscription: Subscription;
 
+    activeRefreshTime: number;
+    refreshTimes: number[];
+    interval: Observable<number>;
+    refreshTimer: Subscription;
+
     constructor(
-        private routesService: JhiRoutesService
+        private routesService: JhiRoutesService,
+        private stateStorageService: StateStorageService,
     ) {
+        this.refreshTimes = [0, 5, 10, 30, 60, 300];
+        this.activeRefreshTime = this.refreshTimes[0];
     }
 
     ngOnInit() {
+        this.activeRoute = this.stateStorageService.getSelectedInstance();
+        this.activeRefreshTime = this.stateStorageService.getSelectedRefreshTime();
+
         this.updateRoute();
         this.routeReloadSubscription = this.routesService.routeReload$.subscribe((reload) => this.updateRoute());
         this.routeDownSubscription = this.routesService.routeDown$.subscribe((route) => {
             this.downRoute(route);
             this.setActiveRoute(null);
         });
+
+        this.launchTimer(false);
     }
 
     ngOnDestroy() {
         /** prevent memory leak when component destroyed **/
         this.routeReloadSubscription.unsubscribe();
+        if (this.refreshTimer) {
+            this.refreshTimer.unsubscribe();
+        }
     }
 
     /** Change active route only if exists, else choose Registry **/
@@ -48,6 +66,7 @@ export class JhiRouteSelectorComponent implements OnInit, OnDestroy {
         } else if (this.routes && this.routes.length > 0) {
             this.activeRoute = this.routes[0];
         }
+        this.stateStorageService.storeSelectedInstance(this.activeRoute);
         this.routesService.routeChange(this.activeRoute);
     }
 
@@ -76,12 +95,38 @@ export class JhiRouteSelectorComponent implements OnInit, OnDestroy {
     }
 
     private downRoute(instance: Route) {
-        if (instance && this.routes) {
-            const index = this.routes.findIndex((r) => r.appName === instance.appName);
-            if (index !== -1) {
-                this.routes[index].status = 'DOWN';
-            }
+        if (instance) {
+            instance.status = 'DOWN';
         }
+    }
+
+    /** Change active time only if exists, else 0 **/
+    setActiveRefreshTime(time: number) {
+        if (time && this.refreshTimes.findIndex((t) => t === time) !== -1) {
+            this.activeRefreshTime = time;
+        } else {
+            this.activeRefreshTime = this.refreshTimes[0];
+        }
+        this.stateStorageService.storeSelectedRefreshTime(time);
+        this.launchTimer(true);
+    }
+
+    /** Init the timer **/
+    subscribe() {
+        if (this.activeRefreshTime && this.activeRefreshTime > 0) {
+            this.interval = Observable.interval(this.activeRefreshTime * 1000);
+            this.refreshTimer = this.interval.subscribe(() => {
+                this.updateRoute();
+            });
+        }
+    }
+
+    /** Launch (or relaunch if true) the timer. **/
+    launchTimer(relaunch: boolean) {
+        if (relaunch && this.refreshTimer) {
+            this.refreshTimer.unsubscribe();
+        }
+        this.subscribe();
     }
 
     /* ==========================================================================
@@ -110,7 +155,7 @@ export class JhiRouteSelectorComponent implements OnInit, OnDestroy {
     state(route: Route) {
         if (route && route.status && route.status === 'DOWN') {
             return 'disabled';
-        } else if (route && route === this.activeRoute) {
+        } else if (route && route.serviceId === this.activeRoute.serviceId) {
             return 'active';
         }
     }
@@ -136,4 +181,25 @@ export class JhiRouteSelectorComponent implements OnInit, OnDestroy {
             dropdown.close();
         }
     }
+
+    getActiveRefreshTime(): string {
+        if (this.activeRefreshTime <= 0) {
+            return 'disabled';
+        }
+        return this.activeRefreshTime + ' sec.';
+    }
+
+    classTime(): string {
+        if (this.activeRefreshTime <= 0) {
+            return 'fa-pause';
+        }
+        return 'fa-refresh';
+    }
+
+    stateTime(time: number): string {
+        if (time === this.activeRefreshTime) {
+            return 'active';
+        }
+    }
+
 }

--- a/src/main/webapp/app/shared/routes/routes.service.ts
+++ b/src/main/webapp/app/shared/routes/routes.service.ts
@@ -8,7 +8,7 @@ import { Route } from './route.model';
 @Injectable()
 export class JhiRoutesService {
 
-    // Observable string sources
+    // Observable sources
     private routeChangedSource = new Subject<Route>();
     private routeDownSource = new Subject<Route>();
     private routeReloadSource = new Subject<boolean>();
@@ -35,6 +35,6 @@ export class JhiRoutesService {
     }
 
     routeDown(route: Route) {
-        this.routeChangedSource.next(route);
+        this.routeDownSource.next(route);
     }
 }

--- a/src/main/webapp/app/shared/routes/routes.service.ts
+++ b/src/main/webapp/app/shared/routes/routes.service.ts
@@ -2,8 +2,8 @@ import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
 import { Subject } from 'rxjs/Subject';
-
 import { Route } from './route.model';
+import { SessionStorageService } from 'ng2-webstorage';
 
 @Injectable()
 export class JhiRoutesService {
@@ -16,7 +16,10 @@ export class JhiRoutesService {
     routeDown$: Observable<Route>;
     routeReload$: Observable<boolean>;
 
-    constructor(private http: Http) {
+    constructor(
+        private http: Http,
+        private sessionStorage: SessionStorageService
+    ) {
         this.routeChanged$ = this.routeChangedSource.asObservable();
         this.routeDown$ = this.routeDownSource.asObservable();
         this.routeReload$ = this.routeReloadSource.asObservable();
@@ -36,5 +39,21 @@ export class JhiRoutesService {
 
     routeDown(route: Route) {
         this.routeDownSource.next(route);
+    }
+
+    getSelectedInstance() {
+        return this.sessionStorage.retrieve('instanceId');
+    }
+
+    storeSelectedInstance(instance) {
+        this.sessionStorage.store('instanceId', instance);
+    }
+
+    getSelectedRefreshTime(): number {
+        return this.sessionStorage.retrieve('refreshTime');
+    }
+
+    storeSelectedRefreshTime(time: number) {
+        this.sessionStorage.store('refreshTime', time);
     }
 }


### PR DESCRIPTION
In accordance with @jdubois, I added two new things.

#### 1. You can choose the refresh time (in seconds) when instances (see #99 #120) are reloaded.

_Of course, as I usually do, a gif to show you :_

![gifpause](https://cloud.githubusercontent.com/assets/11616517/25490220/6eefce3e-2b6c-11e7-8b86-bd4f39a1f917.gif)
<br><br>

#### 2. Moreover, now, your choices are memorized (as session storage, in the StateStorageService component). 

So, you can choose a particular instance (and/or a refresh time) in a admin page, and go to another page, these choices are stored.

#### 3. At last, I changed a little some lines to avoid some inconsistencies.
(routes.services.ts, the 4 admin html pages, ZuulUpdaterService.java). 
In particular to protect when a microservice/gateway fails (even if there are sometimes little problems due to Eureka, like microservices/gateways that are down but that have a 'UP' status...).
<br>
Tell me if you have some questions/suggestions/...