### PR TITLE
[develop] Fix Docker build with Angular

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,19 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8
 
 # Add jhipster-registry source
 ADD . /code/
 
-# Add OpenSSH, package the application and delete all lib
-RUN apk update && apk add openssh && \
+# Package the application and delete all lib
+RUN \
     cd /code/ && \
-    rm -Rf target && \
+    rm -Rf target node_modules && \
     chmod +x /code/mvnw && \
     sleep 1 && \
-    ./mvnw package && \
+    ./mvnw package -Pprod -DskipTests && \
     mv /code/target/*.war /jhipster-registry.war && \
-    rm -Rf /code/ /root/.m2/wrapper/ /root/.m2/repository/ /var/cache/apk/*
+    rm -Rf /code/ /root/.m2 /root/.cache /tmp/*
 
 EXPOSE 8761
-VOLUME /tmp
 
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
     SPRING_PROFILES_ACTIVE=prod,native \


### PR DESCRIPTION
Sorry for other PR https://github.com/jhipster/jhipster-registry/pull/119 from @PierreBesson 
This PR will fix the build for develop branch.

@jdubois :
- the current tests failed (yarn test -> that's why the Dockerfile here will skipTests)
- so you need to merge https://github.com/jhipster/jhipster-registry/pull/127 first
- the global size will change: from 128 MB to 305 MB (because of openjdk:8 instead of alpine)

For people who want to test:
- build: `docker build -t jhipster/jhipster-registry:local .`
- run: `docker run --rm --name registry -p 8761:8761 -e SPRING_PROFILES_ACTIVE=dev,native -e JHIPSTER_SECURITY_AUTHENTICATION_JWT_SECRET=toto jhipster/jhipster-registry:local`