### PR TITLE
Fix #132 Red Starting status & spring cloud config page

### DIFF
--- a/src/main/webapp/app/registry/config/config.component.html
+++ b/src/main/webapp/app/registry/config/config.component.html
@@ -4,16 +4,25 @@
         <jhi-refresh-selector class="float-right refresh-left-side"></jhi-refresh-selector>
     </div>
 
-    <form name="form" role="form" (ngSubmit)="refresh()">
-        <strong>Application: </strong>
-        <input type="text" name="application" [(ngModel)]="application" required class="form-control"
-               uib-typeahead="app for app in applicationList" typeahead-min-length="0">
-        <strong>Profile: </strong>
-        <input type="text" name="profile" [(ngModel)]="profile" required class="form-control">
-        <p *ngIf="isNative">
-            <strong>Git Label: </strong>
-            <input type="text" name="label" [(ngModel)]="label" required class="form-control">
-        </p>
+    <form #form="ngForm" (ngSubmit)="refresh()">
+        <div class="form-group">
+            <label for="application"><strong>Application</strong></label>
+           <select type="text" name="application" id="application" class="form-control" (click)="refresh()"
+                   required [(ngModel)]="application">
+                <option *ngFor="let app of applicationList" [value]="app">{{app}}</option>
+            </select>
+        </div>
+
+        <div class="form-group">
+            <label for="profile"><strong>Profile</strong></label>
+            <input type="text" class="form-control" id="profile" [(ngModel)]="profile" name="profile" required>
+        </div>
+
+        <div class="form-group" *ngIf="isNative">
+            <label for="label"><strong>Git Label: </strong></label>
+            <input type="text" class="form-control" id="label" name="label" [(ngModel)]="label" required>
+        </div>
+        <input type="submit" style="display: none;"> <!-- tips to submit without button -->
     </form>
 
     <div *ngIf="data">

--- a/src/main/webapp/app/registry/config/config.component.ts
+++ b/src/main/webapp/app/registry/config/config.component.ts
@@ -65,16 +65,19 @@ export class JhiConfigComponent implements OnInit, OnDestroy {
         });
 
         this.applicationsService.findAll().subscribe((data) => {
-            data.applications.forEach((application) => {
-                const instanceId = application.instances[0].instanceId;
-                let applicationName;
-                if (instanceId.indexOf(':') === -1) {
-                    applicationName = application.name.toLowerCase();
-                } else {
-                    applicationName = instanceId.substr(0, instanceId.indexOf(':'));
-                }
-                this.applicationList.push(applicationName);
-            });
+            if (data && data.applications) {
+                this.applicationList = ['application'];
+                data.applications.forEach((application) => {
+                    const instanceId = application.instances[0].instanceId;
+                    let applicationName;
+                    if (instanceId.indexOf(':') === -1) {
+                        applicationName = application.name.toLowerCase();
+                    } else {
+                        applicationName = instanceId.substr(0, instanceId.indexOf(':'));
+                    }
+                    this.applicationList.push(applicationName);
+                });
+            }
         });
     }
 }

--- a/src/main/webapp/app/shared/routes/route-selector.component.ts
+++ b/src/main/webapp/app/shared/routes/route-selector.component.ts
@@ -106,10 +106,10 @@ export class JhiRouteSelectorComponent implements OnInit, OnDestroy {
     }
 
     private getBadgeClass(statusState) {
-        if (!statusState || statusState !== 'UP') {
-            return 'badge-danger';
-        } else {
+        if(statusState && (statusState === 'UP' || statusState.toLowerCase() === 'starting')){
             return 'badge-success';
+        } else {
+            return 'badge-danger';
         }
     }
 

--- a/src/main/webapp/app/shared/routes/route-selector.component.ts
+++ b/src/main/webapp/app/shared/routes/route-selector.component.ts
@@ -106,7 +106,7 @@ export class JhiRouteSelectorComponent implements OnInit, OnDestroy {
     }
 
     private getBadgeClass(statusState) {
-        if(statusState && (statusState === 'UP' || statusState.toLowerCase() === 'starting')){
+        if (statusState && (statusState === 'UP' || statusState.toLowerCase() === 'starting')) {
             return 'badge-success';
         } else {
             return 'badge-danger';

--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -26,7 +26,8 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
                 '/management',
                 '/swagger-resources',
                 '/v2/api-docs',
-                '/h2-console'
+                '/h2-console',
+                "/config"
             ],
             target: 'http://127.0.0.1:8761',
             secure: false


### PR DESCRIPTION
Related to #132 :

- Fixed red status instead green
- Added config path to webpack, and update the "form" part (in particular the old typeahead who was not working)

__Note__ : I've tried to use the ng-typeahead, but I always have a `"Cannot read property 'lift' of undefined"` error (maybe in BETA) so before the Registry release, I prefer to use a simple select.

![capture d ecran de 2017-05-05 17-45-48](https://cloud.githubusercontent.com/assets/11616517/25753168/d3ae29a2-31ba-11e7-8408-ca24415e67bc.png)


![capture d ecran de 2017-05-05 17-34-35](https://cloud.githubusercontent.com/assets/11616517/25753169/d3af3040-31ba-11e7-8b05-0e64ba5213da.png)

