### PR TITLE
properly display config git repo and search locations

### DIFF
--- a/src/main/java/io/github/jhipster/registry/web/rest/ProfileInfoResource.java
+++ b/src/main/java/io/github/jhipster/registry/web/rest/ProfileInfoResource.java
@@ -1,11 +1,12 @@
 package io.github.jhipster.registry.web.rest;
 
-import io.github.jhipster.registry.config.DefaultProfileUtil;
-
 import io.github.jhipster.config.JHipsterProperties;
-
+import io.github.jhipster.registry.config.DefaultProfileUtil;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,6 +23,15 @@ public class ProfileInfoResource {
 
     private final JHipsterProperties jHipsterProperties;
 
+    @Value("${spring.cloud.config.server.native.search-locations:}")
+    private String nativeSearchLocation;
+
+    @Value("${spring.cloud.config.server.git.uri:}")
+    private String gitUri;
+
+    @Value("${spring.cloud.config.server.git.search-paths:}")
+    private String gitSearchLocation;
+
     public ProfileInfoResource(Environment env, JHipsterProperties jHipsterProperties) {
         this.env = env;
         this.jHipsterProperties = jHipsterProperties;
@@ -30,7 +40,7 @@ public class ProfileInfoResource {
     @GetMapping("/profile-info")
     public ProfileInfoVM getActiveProfiles() {
         String[] activeProfiles = DefaultProfileUtil.getActiveProfiles(env);
-        return new ProfileInfoVM(activeProfiles, getRibbonEnv(activeProfiles));
+        return new ProfileInfoVM(activeProfiles, getRibbonEnv(activeProfiles), nativeSearchLocation, gitUri, gitSearchLocation);
     }
 
     private String getRibbonEnv(String[] activeProfiles) {
@@ -53,9 +63,19 @@ public class ProfileInfoResource {
 
         private String ribbonEnv;
 
-        ProfileInfoVM(String[] activeProfiles, String ribbonEnv) {
+        private String nativeSearchLocation;
+
+        private String gitUri;
+
+        private String gitSearchLocation;
+
+        ProfileInfoVM(String[] activeProfiles, String ribbonEnv, String nativeSearchLocation, String gitUri,
+                      String gitSearchLocation) {
             this.activeProfiles = activeProfiles;
             this.ribbonEnv = ribbonEnv;
+            this.nativeSearchLocation = nativeSearchLocation;
+            this.gitUri = gitUri;
+            this.gitSearchLocation = gitSearchLocation;
         }
 
         public String[] getActiveProfiles() {
@@ -64,6 +84,18 @@ public class ProfileInfoResource {
 
         public String getRibbonEnv() {
             return ribbonEnv;
+        }
+
+        public String getNativeSearchLocation() {
+            return nativeSearchLocation;
+        }
+
+        public String getGitUri() {
+            return gitUri;
+        }
+
+        public String getGitSearchLocation() {
+            return gitSearchLocation;
         }
     }
 }

--- a/src/main/resources/config/bootstrap-prod.yml
+++ b/src/main/resources/config/bootstrap-prod.yml
@@ -19,7 +19,7 @@ spring:
                 bootstrap: true
             fail-fast: true
             # name of the config server's property source (file.yml) that we want to use
-            name: jhispter-registry
+            name: jhipster-registry
             profile: dev # profile(s) of the property source
             label: master # toggle to switch to a different version of the configuration as stored in git
             # it can be set to any label, branch or commit of the config source git repository

--- a/src/main/resources/config/bootstrap.yml
+++ b/src/main/resources/config/bootstrap.yml
@@ -19,7 +19,7 @@ spring:
                 bootstrap: true
             fail-fast: true
             # name of the config server's property source (file.yml) that we want to use
-            name: jhispter-registry
+            name: jhipster-registry
             profile: dev # profile(s) of the property source
             label: master # toggle to switch to a different version of the configuration as stored in git
             # it can be set to any label, branch or commit of the config source git repository


### PR DESCRIPTION
The ProfileInfo resource doesn't return the config's git information or search paths, they currently appear blank.   This PR returns to the pre v3 behavior
<img width="511" alt="screen shot 2017-06-22 at 3 32 26 pm" src="https://user-images.githubusercontent.com/4294623/27458866-0a573348-5760-11e7-92a0-e20c8e4200bd.png">
