### PR TITLE
Fix bootstrap spring profiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jhipster-registry",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "description": "JHipster service registry, made with Netflix Eureka and Spring Cloud Config",
   "private": true,
   "cacheDirectories": [

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>io.github.jhipster.registry</groupId>
     <artifactId>jhipster-registry</artifactId>
-    <version>3.0.3</version>
+    <version>3.1.0</version>
     <packaging>war</packaging>
     <name>JHipster Registry</name>
     <description>JHipster service registry, made with Netflix Eureka and Spring Cloud Config</description>

--- a/src/main/resources/config/bootstrap-prod.yml
+++ b/src/main/resources/config/bootstrap-prod.yml
@@ -7,7 +7,7 @@ spring:
     application:
         name: jhipster-registry
     profiles:
-        active: prod,git
+        active: prod
     cloud:
         config:
             server:

--- a/src/main/resources/config/bootstrap.yml
+++ b/src/main/resources/config/bootstrap.yml
@@ -7,7 +7,8 @@ spring:
     application:
         name: jhipster-registry
     profiles:
-        active: dev,native
+        active: dev
+        include: native
     cloud:
         config:
             server:


### PR DESCRIPTION
Currently
`target/jhipster-registry-v3.1.0.war --spring.profiles.active=dev` doesn't start the native profile. This PR fixes that.