### PR TITLE
docker: use multi-stage builds to reduce image size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ os:
   - linux
 services:
   - docker
+before_install:
+  - wget -qO- https://get.docker.com/ | sh
+  - docker version
 install:
   - docker build -t jhipster/jhipster-registry:travis .
   - docker images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
-FROM openjdk:8
-
-# Add jhipster-registry source
+FROM openjdk:8 as builder
 ADD . /code/
-
-# Package the application and delete all lib
 RUN \
     cd /code/ && \
     rm -Rf target node_modules && \
@@ -13,11 +9,11 @@ RUN \
     mv /code/target/*.war /jhipster-registry.war && \
     rm -Rf /code/ /root/.m2 /root/.cache /tmp/*
 
-EXPOSE 8761
-
+FROM openjdk:8-jre-alpine
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
     SPRING_PROFILES_ACTIVE=prod,native \
     GIT_URI=https://github.com/jhipster/jhipster-registry/ \
     GIT_SEARCH_PATHS=central-config
-
+EXPOSE 8761
+COPY --from=builder /jhipster-registry.war .
 CMD ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/jhipster-registry.war","--spring.cloud.config.server.git.uri=${GIT_URI}","--spring.cloud.config.server.git.search-paths=${GIT_SEARCH_PATHS}"]


### PR DESCRIPTION
Following the comment here https://github.com/docker/hub-feedback/issues/1039#issuecomment-324020345 : Docker Hub supports multi stage builds with the version 17.06

So it should reduce the docker image size from 352 MB to 113 MB.
@PierreBesson : can you review and test this ?