### PR TITLE
Add .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+target
+node_modules


### PR DESCRIPTION
In my dev environment:
- `target/` : 224MB
- `node_modules` : 424 MB

Those slow down the docker build context creation.