### PR TITLE
Avoids package-info.java erros in Eclipse

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -887,5 +887,35 @@
               </plugins>
             </build>
         </profile>
+        <profile>
+            <id>m2e</id><!--This profile is activated when eclipse interacts with maven (using m2e).-->
+                <activation>
+                    <property>
+                        <name>m2e.version</name>
+                    </property>
+                </activation>
+                <build>
+                    <plugins>
+                        <plugin>
+                            <!--eclipse do not support duplicated package-info.java, in both src and test.-->
+                            <artifactId>maven-compiler-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                <id>default-testCompile</id>
+                                <phase>test-compile</phase>
+                                <configuration>
+                                    <testExcludes>
+                                        <exclude>**/package-info.java</exclude>
+                                    </testExcludes>
+                                </configuration> 
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                                </execution>                  
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </build>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Eclipse marks package-info as duplicate when using eclipse.
Using this configuration fixes the issue

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
