### PR TITLE
fix spring cloud config server version to 1.2.3.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-config-server</artifactId>
+            <version>1.2.3.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>


### PR DESCRIPTION
Revert to an old version of the config server which doesn't have two endpoints differing only by media type.
This is not ideal, but it's better to downgrade only the config server on an old version rather than downgrade the whole release train to Camden.

- [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
