### PR TITLE
secure api endpoints when using OIDC

### DIFF
--- a/src/main/java/io/github/jhipster/registry/config/OAuth2SsoConfiguration.java
+++ b/src/main/java/io/github/jhipster/registry/config/OAuth2SsoConfiguration.java
@@ -33,7 +33,11 @@ public class OAuth2SsoConfiguration extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
             .antMatchers("/services/**").authenticated()
             .antMatchers("/eureka/**").hasAuthority(AuthoritiesConstants.ADMIN)
+            .antMatchers("/api/profile-info").permitAll()
+            .antMatchers("/api/**").authenticated()
             .antMatchers("/config/**").hasAuthority(AuthoritiesConstants.ADMIN)
+            .antMatchers("/management/health").permitAll()
+            .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .anyRequest().permitAll();
     }
 }


### PR DESCRIPTION
This PR makes OAuth2SsoConfiguration secure the same endpoints as OAuth2SecurityConfiguration.  When using the `oauth2` profile, you can currently access several api, eureka, and management endpoints without authenticating.  Because of `/api/account` being open, on the initial visit to the registry URL the page shows as if you are signed in as `anonymousUser` like below:

![screen shot 2017-12-09 at 6 19 39 pm](https://user-images.githubusercontent.com/4294623/33800437-9efd004e-dd0d-11e7-8b0c-04d7003b7356.png)

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
