### PR TITLE
update node and yarn versions to match generator-jhipster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
 FROM openjdk:8 as builder
 ADD . /code/
 RUN \
+    apt-get update && \
+    apt-get install build-essential -y && \
     cd /code/ && \
     rm -Rf target node_modules && \
     chmod +x /code/mvnw && \
     sleep 1 && \
     ./mvnw package -Pprod -DskipTests && \
     mv /code/target/*.war /jhipster-registry.war && \
-    rm -Rf /code/ /root/.m2 /root/.cache /tmp/*
+    apt-get clean && \
+    rm -Rf /code/ /root/.m2 /root/.cache /tmp/* /var/lib/apt/lists/* /var/tmp/*
 
 FROM openjdk:8-jre-alpine
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
         <!-- Build properties -->
         <java.version>1.8</java.version>
         <maven.version>3.0.0</maven.version>
-        <node.version>v6.11.5</node.version>
-        <yarn.version>v1.2.1</yarn.version>
+        <node.version>v8.9.4</node.version>
+        <yarn.version>v1.3.2</yarn.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <project.testresult.directory>${project.build.directory}/test-results</project.testresult.directory>


### PR DESCRIPTION
I was having issues building locally with `mvn -Pwebpack,dev` as I used Node v8 (LTS) when running `yarn install`. Then when I ran `mvn -Pwebpack,dev` on the registry, it crashed telling me to rebuild node-sass for Node v6.  

This does not happen for the `prod` profile because it runs `yarn --force` which rebuilds node dependencies with the node version specified in the pom.xml.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
