### PR TITLE
remove double docker install on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ os:
   - linux
 services:
   - docker
-before_install:
-  - wget -qO- https://get.docker.com/ | sh
-  - docker version
 install:
   - docker build -t jhipster/jhipster-registry:travis .
   - docker images


### PR DESCRIPTION
>Executing docker install script, commit: 1d31602
Warning: the "docker" command appears to already exist on this system.
If you already have Docker installed, this script can cause trouble, which is
why we're displaying this warning and provide the opportunity to cancel the
installation.

https://travis-ci.org/jhipster/jhipster-registry/builds/324840407#L522-L527


- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
