### PR TITLE
Only forward metric log to logstash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,11 +28,11 @@
         <profile.swagger />
 
         <!-- Dependency versions -->
-        <jhipster-dependencies.version>0.1.4</jhipster-dependencies.version>
+        <jhipster-dependencies.version>0.1.9</jhipster-dependencies.version>
         <mapstruct.version>1.2.0.Final</mapstruct.version>
         <!-- The spring-boot version should match the one managed by
         https://mvnrepository.com/artifact/io.github.jhipster/jhipster-dependencies/${jhipster-dependencies.version} -->
-        <spring-boot.version>1.5.9.RELEASE</spring-boot.version>
+        <spring-boot.version>1.5.11.RELEASE</spring-boot.version>
 
         <!-- Plugin versions -->
         <maven-clean-plugin.version>2.6.1</maven-clean-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.github.jhipster.registry</groupId>
     <artifactId>jhipster-registry</artifactId>
-    <version>3.2.5</version>
+    <version>3.2.6</version>
     <packaging>war</packaging>
     <name>JHipster Registry</name>
     <description>JHipster service registry, made with Netflix Eureka and Spring Cloud Config</description>

--- a/pom.xml
+++ b/pom.xml
@@ -28,11 +28,11 @@
         <profile.swagger />
 
         <!-- Dependency versions -->
-        <jhipster-dependencies.version>0.1.9</jhipster-dependencies.version>
+        <jhipster-dependencies.version>0.1.4</jhipster-dependencies.version>
         <mapstruct.version>1.2.0.Final</mapstruct.version>
         <!-- The spring-boot version should match the one managed by
         https://mvnrepository.com/artifact/io.github.jhipster/jhipster-dependencies/${jhipster-dependencies.version} -->
-        <spring-boot.version>1.5.11.RELEASE</spring-boot.version>
+        <spring-boot.version>1.5.9.RELEASE</spring-boot.version>
 
         <!-- Plugin versions -->
         <maven-clean-plugin.version>2.6.1</maven-clean-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.github.jhipster.registry</groupId>
     <artifactId>jhipster-registry</artifactId>
-    <version>3.2.4</version>
+    <version>3.2.5</version>
     <packaging>war</packaging>
     <name>JHipster Registry</name>
     <description>JHipster service registry, made with Netflix Eureka and Spring Cloud Config</description>

--- a/src/main/java/io/github/jhipster/registry/config/LoggingConfiguration.java
+++ b/src/main/java/io/github/jhipster/registry/config/LoggingConfiguration.java
@@ -76,6 +76,12 @@ public class LoggingConfiguration {
         asyncLogstashAppender.start();
 
         context.getLogger("ROOT").addAppender(asyncLogstashAppender);
+        
+        // Only forward metric log to logstash
+        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) context.getLogger("metrics");
+        logger.addAppender(asyncLogstashAppender);
+        logger.setLevel(Level.ALL);
+        logger.setAdditive(false);
     }
 
     /**

--- a/src/main/java/io/github/jhipster/registry/config/LoggingConfiguration.java
+++ b/src/main/java/io/github/jhipster/registry/config/LoggingConfiguration.java
@@ -1,21 +1,36 @@
 package io.github.jhipster.registry.config;
 
+import java.net.InetSocketAddress;
+import java.util.Iterator;
+
 import io.github.jhipster.config.JHipsterProperties;
 
 import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.boolex.OnMarkerEvaluator;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggerContextListener;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.filter.EvaluatorFilter;
 import ch.qos.logback.core.spi.ContextAwareBase;
-import net.logstash.logback.appender.LogstashSocketAppender;
+import ch.qos.logback.core.spi.FilterReply;
+import net.logstash.logback.appender.LogstashTcpSocketAppender;
+import net.logstash.logback.encoder.LogstashEncoder;
 import net.logstash.logback.stacktrace.ShortenedThrowableConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
+@RefreshScope
 public class LoggingConfiguration {
+
+    private static final String LOGSTASH_APPENDER_NAME = "LOGSTASH";
+
+    private static final String ASYNC_LOGSTASH_APPENDER_NAME = "ASYNC_LOGSTASH";
 
     private final Logger log = LoggerFactory.getLogger(LoggingConfiguration.class);
 
@@ -25,63 +40,91 @@ public class LoggingConfiguration {
 
     private final String serverPort;
 
-    private final String instanceId;
+    private final String version;
 
     private final JHipsterProperties jHipsterProperties;
 
     public LoggingConfiguration(@Value("${spring.application.name}") String appName, @Value("${server.port}") String serverPort,
-        @Value("${eureka.instance.instanceId}") String instanceId, JHipsterProperties jHipsterProperties) {
+         @Value("${info.project.version:}") String version, JHipsterProperties jHipsterProperties) {
         this.appName = appName;
         this.serverPort = serverPort;
-        this.instanceId = instanceId;
+        this.version = version;
         this.jHipsterProperties = jHipsterProperties;
         if (jHipsterProperties.getLogging().getLogstash().isEnabled()) {
             addLogstashAppender(context);
-
-            // Add context listener
-            LogbackLoggerContextListener loggerContextListener = new LogbackLoggerContextListener();
-            loggerContextListener.setContext(context);
-            context.addListener(loggerContextListener);
+            addContextListener(context);
+        }
+        if (jHipsterProperties.getMetrics().getLogs().isEnabled()) {
+            setMetricsMarkerLogbackFilter(context);
         }
     }
 
-    public void addLogstashAppender(LoggerContext context) {
+    private void addContextListener(LoggerContext context) {
+        LogbackLoggerContextListener loggerContextListener = new LogbackLoggerContextListener();
+        loggerContextListener.setContext(context);
+        context.addListener(loggerContextListener);
+    }
+
+    private void addLogstashAppender(LoggerContext context) {
         log.info("Initializing Logstash logging");
 
-        LogstashSocketAppender logstashAppender = new LogstashSocketAppender();
-        logstashAppender.setName("LOGSTASH");
+        LogstashTcpSocketAppender logstashAppender = new LogstashTcpSocketAppender();
+        logstashAppender.setName(LOGSTASH_APPENDER_NAME);
         logstashAppender.setContext(context);
+        String optionalFields = "";
         String customFields = "{\"app_name\":\"" + appName + "\",\"app_port\":\"" + serverPort + "\"," +
-            "\"instance_id\":\"" + instanceId + "\"}";
+            optionalFields + "\"version\":\"" + version + "\"}";
 
+        // More documentation is available at: https://github.com/logstash/logstash-logback-encoder
+        LogstashEncoder logstashEncoder = new LogstashEncoder();
         // Set the Logstash appender config from JHipster properties
-        logstashAppender.setSyslogHost(jHipsterProperties.getLogging().getLogstash().getHost());
-        logstashAppender.setPort(jHipsterProperties.getLogging().getLogstash().getPort());
-        logstashAppender.setCustomFields(customFields);
+        logstashEncoder.setCustomFields(customFields);
+        // Set the Logstash appender config from JHipster properties
+        logstashAppender.addDestinations(new InetSocketAddress(jHipsterProperties.getLogging().getLogstash().getHost(), jHipsterProperties.getLogging().getLogstash().getPort()));
 
-        // Limit the maximum length of the forwarded stacktrace so that it won't exceed the 8KB UDP limit of logstash
         ShortenedThrowableConverter throwableConverter = new ShortenedThrowableConverter();
-        throwableConverter.setMaxLength(7500);
         throwableConverter.setRootCauseFirst(true);
-        logstashAppender.setThrowableConverter(throwableConverter);
+        logstashEncoder.setThrowableConverter(throwableConverter);
+        logstashEncoder.setCustomFields(customFields);
 
+        logstashAppender.setEncoder(logstashEncoder);
         logstashAppender.start();
 
         // Wrap the appender in an Async appender for performance
         AsyncAppender asyncLogstashAppender = new AsyncAppender();
         asyncLogstashAppender.setContext(context);
-        asyncLogstashAppender.setName("ASYNC_LOGSTASH");
+        asyncLogstashAppender.setName(ASYNC_LOGSTASH_APPENDER_NAME);
         asyncLogstashAppender.setQueueSize(jHipsterProperties.getLogging().getLogstash().getQueueSize());
         asyncLogstashAppender.addAppender(logstashAppender);
         asyncLogstashAppender.start();
 
         context.getLogger("ROOT").addAppender(asyncLogstashAppender);
-        
-        // Only forward metric log to logstash
-        ch.qos.logback.classic.Logger logger = (ch.qos.logback.classic.Logger) context.getLogger("metrics");
-        logger.addAppender(asyncLogstashAppender);
-        logger.setLevel(Level.ALL);
-        logger.setAdditive(false);
+    }
+
+    // Configure a log filter to remove "metrics" logs from all appenders except the "LOGSTASH" appender
+    private void setMetricsMarkerLogbackFilter(LoggerContext context) {
+        log.info("Filtering metrics logs from all appenders except the {} appender", LOGSTASH_APPENDER_NAME);
+        OnMarkerEvaluator onMarkerMetricsEvaluator = new OnMarkerEvaluator();
+        onMarkerMetricsEvaluator.setContext(context);
+        onMarkerMetricsEvaluator.addMarker("metrics");
+        onMarkerMetricsEvaluator.start();
+        EvaluatorFilter<ILoggingEvent> metricsFilter = new EvaluatorFilter<>();
+        metricsFilter.setContext(context);
+        metricsFilter.setEvaluator(onMarkerMetricsEvaluator);
+        metricsFilter.setOnMatch(FilterReply.DENY);
+        metricsFilter.start();
+
+        for (ch.qos.logback.classic.Logger logger : context.getLoggerList()) {
+            for (Iterator<Appender<ILoggingEvent>> it = logger.iteratorForAppenders(); it.hasNext();) {
+                Appender<ILoggingEvent> appender = it.next();
+                if (!appender.getName().equals(ASYNC_LOGSTASH_APPENDER_NAME)) {
+                    log.debug("Filter metrics logs from the {} appender", appender.getName());
+                    appender.setContext(context);
+                    appender.addFilter(metricsFilter);
+                    appender.start();
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Current metrics log make console of registry very hard to read another log, so only forward metric log to logstash, not log metrics to console. This make easier when need to check registry error.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
