### PR TITLE
Set node and yarn version in package.json engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,8 @@
     "yargs": "6.6.0"
   },
   "engines": {
-    "node": ">=6.9.0"
+    "node": ">=8.2.11 <10",
+    "yarn": "1.3.2"
   },
   "scripts": {
     "lint": "tslint 'src/main/webapp/app/**/*.ts'",


### PR DESCRIPTION
My JHipster Registry deploys are failing with Node 10+. If there is a way to say that you want the latest LTS version of node, that would probably be better, but I don't know of such a mechanism.

I've also added a Yarn engine version to ensure it aligns with what's in `pom.xml`.