### PR TITLE
switch to composite mode for defining the configserver sources

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,16 +15,12 @@ RUN \
 FROM openjdk:8-jre-alpine
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
     JAVA_OPTS="" \
-    SPRING_PROFILES_ACTIVE=prod,native \
-    GIT_URI=https://github.com/jhipster/jhipster-registry/ \
-    GIT_SEARCH_PATHS=central-config
+    SPRING_PROFILES_ACTIVE=prod
 EXPOSE 8761
 RUN mkdir /target && \
     chmod g+rwx /target
 CMD java \
         ${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom \
-        -jar /jhipster-registry.war \
-        --spring.cloud.config.server.git.uri=${GIT_URI} \
-        --spring.cloud.config.server.git.search-paths=${GIT_SEARCH_PATHS}
+        -jar /jhipster-registry.war
 
 COPY --from=builder /jhipster-registry.war .

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: java $JAVA_OPTS -jar target/*.war --spring.profiles.active=prod,native,heroku --server.port=$PORT --spring.security.user.password=${JHIPSTER_PASSWORD:-"password"} --eureka.password=${JHIPSTER_PASSWORD:-"password"}
+web: java $JAVA_OPTS -jar target/*.war --spring.profiles.active=prod,heroku --server.port=$PORT --spring.security.user.password=${JHIPSTER_PASSWORD:-"password"} --eureka.password=${JHIPSTER_PASSWORD:-"password"}

--- a/src/main/java/io/github/jhipster/registry/JHipsterRegistryApp.java
+++ b/src/main/java/io/github/jhipster/registry/JHipsterRegistryApp.java
@@ -1,6 +1,7 @@
 package io.github.jhipster.registry;
 
 import io.github.jhipster.registry.config.ApplicationProperties;
+import io.github.jhipster.registry.config.ConfigServerConfig;
 import io.github.jhipster.registry.config.DefaultProfileUtil;
 
 import io.github.jhipster.config.JHipsterConstants;
@@ -25,7 +26,7 @@ import java.util.Collection;
 @EnableEurekaServer
 @EnableConfigServer
 @SpringBootApplication
-@EnableConfigurationProperties({ApplicationProperties.class})
+@EnableConfigurationProperties({ApplicationProperties.class, ConfigServerConfig.class})
 @EnableDiscoveryClient
 @EnableZuulProxy
 public class JHipsterRegistryApp {

--- a/src/main/java/io/github/jhipster/registry/JHipsterRegistryApp.java
+++ b/src/main/java/io/github/jhipster/registry/JHipsterRegistryApp.java
@@ -105,5 +105,9 @@ public class JHipsterRegistryApp {
                 "Please read the documentation at http://www.jhipster.tech/jhipster-registry/\n" +
                 "----------------------------------------------------------");
         }
+        String configServerStatus = env.getProperty("configserver.status");
+        log.info("\n----------------------------------------------------------\n\t" +
+                "Config Server: \t{}\n----------------------------------------------------------",
+            configServerStatus == null ? "Not found or not setup for this application" : configServerStatus);
     }
 }

--- a/src/main/java/io/github/jhipster/registry/config/ConfigServerConfig.java
+++ b/src/main/java/io/github/jhipster/registry/config/ConfigServerConfig.java
@@ -1,0 +1,17 @@
+package io.github.jhipster.registry.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.cloud.config.server")
+public class ConfigServerConfig {
+
+    private List<Map<String, Object>> composite = new ArrayList<>();
+
+    public List<Map<String, Object>> getComposite() {
+        return composite;
+    }
+}

--- a/src/main/java/io/github/jhipster/registry/config/NativeRepositoryConfiguration.java
+++ b/src/main/java/io/github/jhipster/registry/config/NativeRepositoryConfiguration.java
@@ -1,0 +1,26 @@
+package io.github.jhipster.registry.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.cloud.config.server.environment.EnvironmentRepository;
+import org.springframework.cloud.config.server.environment.NativeEnvironmentProperties;
+import org.springframework.cloud.config.server.environment.NativeEnvironmentRepository;
+import org.springframework.cloud.config.server.environment.NativeEnvironmentRepositoryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@ConditionalOnMissingBean(EnvironmentRepository.class)
+@Profile("native")
+class NativeRepositoryConfiguration {
+
+    @Autowired
+    private NativeEnvironmentRepositoryFactory nativeEnvironmentRepositoryFactory;
+
+    @Bean
+    public NativeEnvironmentRepository nativeEnvironmentRepository(NativeEnvironmentRepositoryFactory factory,
+                                                                   NativeEnvironmentProperties environmentProperties) {
+        return factory.build(environmentProperties);
+    }
+}

--- a/src/main/java/io/github/jhipster/registry/web/rest/ProfileInfoResource.java
+++ b/src/main/java/io/github/jhipster/registry/web/rest/ProfileInfoResource.java
@@ -1,8 +1,8 @@
 package io.github.jhipster.registry.web.rest;
 
 import io.github.jhipster.config.JHipsterProperties;
+import io.github.jhipster.registry.config.ConfigServerConfig;
 import io.github.jhipster.registry.config.DefaultProfileUtil;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Resource to return information about the currently running Spring profiles.
@@ -23,24 +24,19 @@ public class ProfileInfoResource {
 
     private final JHipsterProperties jHipsterProperties;
 
-    @Value("${spring.cloud.config.server.native.search-locations:}")
-    private String nativeSearchLocation;
+    private final ConfigServerConfig configServerConfig;
 
-    @Value("${spring.cloud.config.server.git.uri:}")
-    private String gitUri;
-
-    @Value("${spring.cloud.config.server.git.search-paths:}")
-    private String gitSearchLocation;
-
-    public ProfileInfoResource(Environment env, JHipsterProperties jHipsterProperties) {
+    public ProfileInfoResource(Environment env, JHipsterProperties jHipsterProperties, ConfigServerConfig configServerConfig) {
         this.env = env;
         this.jHipsterProperties = jHipsterProperties;
+        this.configServerConfig = configServerConfig;
     }
 
     @GetMapping("/profile-info")
     public ProfileInfoVM getActiveProfiles() {
         String[] activeProfiles = DefaultProfileUtil.getActiveProfiles(env);
-        return new ProfileInfoVM(activeProfiles, getRibbonEnv(activeProfiles), nativeSearchLocation, gitUri, gitSearchLocation);
+
+        return new ProfileInfoVM(activeProfiles, getRibbonEnv(activeProfiles), configServerConfig.getComposite());
     }
 
     private String getRibbonEnv(String[] activeProfiles) {
@@ -63,19 +59,12 @@ public class ProfileInfoResource {
 
         private String ribbonEnv;
 
-        private String nativeSearchLocation;
+        private List<Map<String, Object>> configurationSources;
 
-        private String gitUri;
-
-        private String gitSearchLocation;
-
-        ProfileInfoVM(String[] activeProfiles, String ribbonEnv, String nativeSearchLocation, String gitUri,
-                      String gitSearchLocation) {
+        ProfileInfoVM(String[] activeProfiles, String ribbonEnv, List<Map<String, Object>> configurationSources) {
             this.activeProfiles = activeProfiles;
             this.ribbonEnv = ribbonEnv;
-            this.nativeSearchLocation = nativeSearchLocation;
-            this.gitUri = gitUri;
-            this.gitSearchLocation = gitSearchLocation;
+            this.configurationSources = configurationSources;
         }
 
         public String[] getActiveProfiles() {
@@ -86,16 +75,8 @@ public class ProfileInfoResource {
             return ribbonEnv;
         }
 
-        public String getNativeSearchLocation() {
-            return nativeSearchLocation;
-        }
-
-        public String getGitUri() {
-            return gitUri;
-        }
-
-        public String getGitSearchLocation() {
-            return gitSearchLocation;
+        public List<Map<String, Object>> getConfigurationSources() {
+            return configurationSources;
         }
     }
 }

--- a/src/main/resources/config/bootstrap-git.yml
+++ b/src/main/resources/config/bootstrap-git.yml
@@ -7,16 +7,15 @@ spring:
     application:
         name: jhipster-registry
     profiles:
-        active: prod,git
+        include: git
     cloud:
         config:
             server:
-                git:
-                    uri: https://github.com/jhipster/jhipster-registry-sample-config
-                native:
-                    search-locations: file:./central-config
-                prefix: /config
                 bootstrap: true
+                composite:
+                    - type: git
+                      uri: https://github.com/jhipster/jhipster-registry-sample-config
+                prefix: /config
             fail-fast: true
             # name of the config server's property source (file.yml) that we want to use
             name: jhipster-registry

--- a/src/main/resources/config/bootstrap-prod.yml
+++ b/src/main/resources/config/bootstrap-prod.yml
@@ -4,10 +4,8 @@
 # ===================================================================
 
 spring:
-    application:
-        name: jhipster-registry
     profiles:
-        include: git
+        active: prod
     cloud:
         config:
             server:
@@ -22,7 +20,3 @@ spring:
             profile: prod # profile(s) of the property source
             label: master # toggle to switch to a different version of the configuration as stored in git
             # it can be set to any label, branch or commit of the config source git repository
-
-info:
-    project:
-        version: #project.version#

--- a/src/main/resources/config/bootstrap.yml
+++ b/src/main/resources/config/bootstrap.yml
@@ -7,16 +7,16 @@ spring:
     application:
         name: jhipster-registry
     profiles:
-        active: dev,native
+        active: dev
+        include: composite
     cloud:
         config:
             server:
-                git:
-                    uri: https://github.com/jhipster/jhipster-registry-sample-config
-                native:
-                    search-locations: file:./central-config
                 prefix: /config
                 bootstrap: true
+                composite:
+                    - type: native
+                      search-locations: file:./central-config
             fail-fast: true
             # name of the config server's property source (file.yml) that we want to use
             name: jhipster-registry

--- a/src/main/resources/config/bootstrap.yml
+++ b/src/main/resources/config/bootstrap.yml
@@ -17,6 +17,9 @@ spring:
                 composite:
                     - type: native
                       search-locations: file:./central-config
+                    - type: git
+                      uri: https://github.com/jhipster/jhipster-registry-sample-config
+                      ble: yolo
             fail-fast: true
             # name of the config server's property source (file.yml) that we want to use
             name: jhipster-registry

--- a/src/main/resources/config/bootstrap.yml
+++ b/src/main/resources/config/bootstrap.yml
@@ -17,9 +17,6 @@ spring:
                 composite:
                     - type: native
                       search-locations: file:./central-config
-                    - type: git
-                      uri: https://github.com/jhipster/jhipster-registry-sample-config
-                      ble: yolo
             fail-fast: true
             # name of the config server's property source (file.yml) that we want to use
             name: jhipster-registry

--- a/src/main/resources/config/bootstrap.yml
+++ b/src/main/resources/config/bootstrap.yml
@@ -12,11 +12,11 @@ spring:
     cloud:
         config:
             server:
-                prefix: /config
                 bootstrap: true
                 composite:
                     - type: native
                       search-locations: file:./central-config
+                prefix: /config
             fail-fast: true
             # name of the config server's property source (file.yml) that we want to use
             name: jhipster-registry

--- a/src/main/webapp/app/layouts/profiles/profile-info.model.ts
+++ b/src/main/webapp/app/layouts/profiles/profile-info.model.ts
@@ -3,7 +3,5 @@ export class ProfileInfo {
     ribbonEnv: string;
     inProduction: boolean;
     swaggerEnabled: boolean;
-    nativeSearchLocation?: string;
-    gitUri?: string;
-    gitSearchLocation?: string;
+    configurationSources: Array<any>;
 }

--- a/src/main/webapp/app/layouts/profiles/profile.service.ts
+++ b/src/main/webapp/app/layouts/profiles/profile.service.ts
@@ -20,8 +20,7 @@ export class ProfileService {
                     const pi = new ProfileInfo();
                     pi.activeProfiles = data.activeProfiles;
                     pi.ribbonEnv = data.ribbonEnv;
-                    pi.nativeSearchLocation = data.nativeSearchLocation;
-                    pi.gitSearchLocation = data.gitSearchLocation;
+                    pi.configurationSources = data.configurationSources;
                     pi.inProduction = data.activeProfiles.includes('prod');
                     pi.swaggerEnabled = data.activeProfiles.includes('swagger');
                     return pi;

--- a/src/main/webapp/app/registry/config/config.component.html
+++ b/src/main/webapp/app/registry/config/config.component.html
@@ -7,7 +7,8 @@
     <form #form="ngForm" (ngSubmit)="refresh()">
         <div class="form-group">
             <label for="profile"><strong>Application</strong></label>
-            <input type="text" class="form-control" id="application" [(ngModel)]="application" name="application" required>
+            <input type="text" class="form-control" id="application" [(ngModel)]="application" name="application"
+                   required>
         </div>
 
         <div class="form-group">
@@ -72,7 +73,7 @@
             <td>{{ index }}</td>
             <td>
                 <ul>
-                    <li *ngFor="let prop of getKeys(source)">{{ prop }}: {{ source[prop] }}</li>
+                    <li *ngFor="let prop of getKeys(source)">{{ prop }}: {{ source[prop] | json}}</li>
                 </ul>
             </td>
         </tr>

--- a/src/main/webapp/app/registry/config/config.component.html
+++ b/src/main/webapp/app/registry/config/config.component.html
@@ -61,24 +61,20 @@
         </ngb-tabset>
     </div>
 
-    <h3 class="head bottom">Configuration Source Information</h3>
-    <table class="table table-striped ">
+    <h3 class="head bottom">Configuration Sources</h3>
+    <table class="table table-striped">
         <thead>
-        <tr>
-            <th>Type</th>
-            <th *ngIf="!isNative">Repository URI</th>
-            <th>Location</th>
-        </tr>
+            <th>Index</th>
+            <th>Configuration</th>
         </thead>
         <tbody>
-        <tr *ngIf="isNative">
-            <td>Native (Local Filesystem)</td>
-            <td>{{ nativeSearchLocation }}</td>
-        </tr>
-        <tr *ngIf="!isNative">
-            <td>Git</td>
-            <td>{{ gitUri }}</td>
-            <td>/{{ gitSearchLocation }}</td>
+        <tr *ngFor="let source of configurationSources; let index=index">
+            <td>{{ index }}</td>
+            <td>
+                <ul>
+                    <li *ngFor="let prop of getKeys(source)">{{ prop }}: {{ source[prop] }}</li>
+                </ul>
+            </td>
         </tr>
         </tbody>
     </table>

--- a/src/main/webapp/app/registry/config/config.component.ts
+++ b/src/main/webapp/app/registry/config/config.component.ts
@@ -15,9 +15,7 @@ export class JhiConfigComponent implements OnInit, OnDestroy {
     label: string;
     activeRegistryProfiles: any;
     isNative: boolean;
-    nativeSearchLocation: string;
-    gitUri: string;
-    gitSearchLocation: string;
+    configurationSources: Array<any>;
     configAsYaml: any;
     configAsProperties: any;
     configAsJson: any;
@@ -53,9 +51,7 @@ export class JhiConfigComponent implements OnInit, OnDestroy {
         this.profileService.getProfileInfo().then((response) => {
             this.activeRegistryProfiles = response.activeProfiles;
             this.isNative = this.activeRegistryProfiles.includes('native');
-            this.nativeSearchLocation = response.nativeSearchLocation;
-            this.gitUri = response.gitUri;
-            this.gitSearchLocation = response.gitSearchLocation;
+            this.configurationSources = response.configurationSources;
         });
 
         this.refreshReloadSubscription = this.refreshService.refreshReload$.subscribe((empty) => this.refresh());
@@ -111,5 +107,9 @@ export class JhiConfigComponent implements OnInit, OnDestroy {
                 });
             }
         });
+    }
+
+    getKeys(obj: Object) {
+        return Object.keys(obj);
     }
 }

--- a/src/main/webapp/app/registry/registry.module.ts
+++ b/src/main/webapp/app/registry/registry.module.ts
@@ -1,6 +1,7 @@
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { JHipsterRegistrySharedModule } from '../shared';
+import { CommonModule } from '@angular/common';
 
 import {
     registryState,
@@ -19,7 +20,7 @@ import {
 } from './';
 
 @NgModule({
-    imports: [JHipsterRegistrySharedModule, RouterModule.forRoot(registryState, { useHash: true })],
+    imports: [JHipsterRegistrySharedModule, CommonModule, RouterModule.forRoot(registryState, { useHash: true })],
     declarations: [
         JhiApplicationsComponent,
         JhiConfigComponent,


### PR DESCRIPTION
Fix https://github.com/jhipster/jhipster-registry/issues/281

Use the new composite feature of the config server. This allow us to remove the confusing native profile and be able to define several sources at once.
This also fixes the but with the bootstrap + native.

- [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
