### PR TITLE
fix issue with MetricsMarkerLogbackFilter

### DIFF
--- a/src/main/java/io/github/jhipster/registry/config/MetricsConfiguration.java
+++ b/src/main/java/io/github/jhipster/registry/config/MetricsConfiguration.java
@@ -10,6 +10,8 @@ import com.ryantenney.metrics.spring.config.annotation.MetricsConfigurerAdapter;
 import io.github.jhipster.config.JHipsterProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -65,6 +67,7 @@ public class MetricsConfiguration extends MetricsConfigurerAdapter {
         }
         if (jHipsterProperties.getMetrics().getLogs().isEnabled()) {
             log.info("Initializing Metrics Log reporting");
+            Marker metricsMarker = MarkerFactory.getMarker("metrics");
             final Slf4jReporter reporter = Slf4jReporter.forRegistry(metricRegistry)
                 .outputTo(LoggerFactory.getLogger("metrics"))
                 .convertRatesTo(TimeUnit.SECONDS)

--- a/src/main/java/io/github/jhipster/registry/config/MetricsConfiguration.java
+++ b/src/main/java/io/github/jhipster/registry/config/MetricsConfiguration.java
@@ -70,6 +70,7 @@ public class MetricsConfiguration extends MetricsConfigurerAdapter {
             Marker metricsMarker = MarkerFactory.getMarker("metrics");
             final Slf4jReporter reporter = Slf4jReporter.forRegistry(metricRegistry)
                 .outputTo(LoggerFactory.getLogger("metrics"))
+                .markWith(metricsMarker)
                 .convertRatesTo(TimeUnit.SECONDS)
                 .convertDurationsTo(TimeUnit.MILLISECONDS)
                 .build();


### PR DESCRIPTION
The `MetricsMarkerLogbackFilter` will set a `OnMarkerEvaluator` to filter out all the log marked with "metric".
In order to make the above filter work, we need to set the "marker" for all metric log.



- Please make sure the below checklist is followed for Pull Requests.

- [X] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
