### PR TITLE
Fix decryption in Encryption UI

### DIFF
--- a/src/main/webapp/app/registry/encryption/encryption.component.ts
+++ b/src/main/webapp/app/registry/encryption/encryption.component.ts
@@ -35,7 +35,7 @@ export class JhiEncryptionComponent implements OnInit, OnDestroy {
     }
 
     decrypt() {
-        this.encryptionService.decrypt(this.encryptedText).subscribe(
+        this.encryptionService.decrypt(this.encryptedText.replace(/^{cipher}/, '')).subscribe(
             (response) => {
                 this.result = response;
                 this.textToEncrypt = response;


### PR DESCRIPTION
The {cipher} marker needs to be stripped before passing the
encrypted value to the decryption endpoint

The spring-cloud-config docs also do not use the `{cipher}` part. But I think its really helpful you are appending it to the encrypted value (to allow copy and pasting it into configs)

Reproduce
```
curl localhost:8761/config/encrypt -d mysecret -u admin:admin
```
```
curl localhost:8761/config/decrypt -d $ENCRYPTED_VALUE -u admin:admin
```
works fine

```
curl localhost:8761/config/decrypt -d {cipher}$ENCRYPTED_VALUE -u admin:admin
```

leads to
```json
{
  "description" : "Text not encrypted with this key",
  "status" : "INVALID"
}
```
- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
