### PR TITLE
Updated app.json to use jhipster registry buildpack

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: java $JAVA_OPTS -jar target/*.war --spring.profiles.active=prod,heroku --server.port=$PORT --spring.security.user.password=${JHIPSTER_PASSWORD:-"password"} --eureka.password=${JHIPSTER_PASSWORD:-"password"} $SPRING_OPTS

--- a/app.json
+++ b/app.json
@@ -15,17 +15,13 @@
       "description": "Spring Boot options.",
       "value": "--server.undertow.io-threads=1 --server.undertow.eager-filter-init=false"
     },
-    "MAVEN_CUSTOM_OPTS": {
-        "description": "Options for the Maven build.",
-        "value": "-Pprod,heroku -DskipTests"
-    },
-    "NPM_CONFIG_PRODUCTION": {
-        "description": "Set to false to install devDependencies",
-        "value": "false"
+    "JHIPSTER_REGISTRY_VERSION": {
+      "description": "Version of the registry to deploy.",
+      "value": "4.0.4"
     }
   },
   "buildpacks": [
-    {"url": "heroku/nodejs"},
-    {"url": "heroku/java"}
+    {"url": "heroku/jvm"},
+    {"url": "https://github.com/jkutner/jhipster-registry-buildpack"}
   ]
 }


### PR DESCRIPTION
This change uses the [JHipster Registry Buildpack](https://github.com/jkutner/jhipster-registry-buildpack) to download and install a precompiled version of the JHipster Registry (instead of buildpack from source).

Building from source takes a long time, and only supports the default Github branch. Users probably don't want to deploy the latest code, but a stable version instead.

Deployment still works by clicking the "Deploy to Heroku" button in the README (i.e. no difference to user experience or docs).

/cc @mraible 

### Future work

We shouldn't use the Github URL to my custom buildpack. Instead we should adopt one of the following:

* Move the [JHipster Registry Buildpack](https://github.com/jkutner/jhipster-registry-buildpack) into the [jhipster Github org](https://github.com/jhipster/).
* Move the `bin/` directory of the [jkutner/jhipster-registry-buildpack](https://github.com/jkutner/jhipster-registry-buildpack) to *this* repo (such that it becomes a self-contained buildpack)

I'll submit a PR for one of these once it's decided. In either case, we'll publish it to the [Buildpack Registry](https://devcenter.heroku.com/articles/buildpack-registry) as `jhipster/registry`.
