### PR TITLE
extracts the 'refresh now' button on top

### DIFF
--- a/src/main/webapp/app/shared/refresh/refresh-selector.component.html
+++ b/src/main/webapp/app/shared/refresh/refresh-selector.component.html
@@ -1,4 +1,7 @@
 <div ngbDropdown placement="bottom-right">
+    <button class="btn btn-outline-primary" (click)="manualRefresh()">
+        <span class="times-text">Refresh now <i class="fa fa-refresh"></i></span>
+    </button>
     <button class="btn btn-outline-primary times" [ngClass]="classTime()" id="refreshMenu" ngbDropdownToggle>
         &nbsp; <span class="times-text" [innerHTML]="getActiveRefreshTime()"></span>
     </button>
@@ -10,9 +13,5 @@
                 <ng-template #disabledTemplate>disabled</ng-template>
             </button>
         </div>
-        <div class="dropdown-divider"></div>
-        <button class="dropdown-item manual-refresh" (click)="manualRefresh()">
-            Refresh now &nbsp;<span class="fa fa-refresh"></span>
-        </button>
     </div>
 </div>

--- a/src/main/webapp/app/shared/refresh/refresh-selector.component.html
+++ b/src/main/webapp/app/shared/refresh/refresh-selector.component.html
@@ -3,7 +3,7 @@
         <span class="times-text">Refresh now <i class="fa fa-refresh"></i></span>
     </button>
     <button class="btn btn-outline-primary times" id="refreshMenu" ngbDropdownToggle>
-        <i [ngClass]="classTime()" ></i>&nbsp; <span class="times-text" [innerHTML]="getActiveRefreshTime()"></span>
+        <i [ngClass]="classTime()" ></i>&nbsp; <span class="times-text">{{getActiveRefreshTime()}}</span>
     </button>
     <div ngbDropdownMenu aria-labelledby="refreshMenu" aria-expanded="true">
         <span class="dropdown-header">Refresh times (in seconds)</span>

--- a/src/main/webapp/app/shared/refresh/refresh-selector.component.html
+++ b/src/main/webapp/app/shared/refresh/refresh-selector.component.html
@@ -2,8 +2,8 @@
     <button class="btn btn-outline-primary" (click)="manualRefresh()">
         <span class="times-text">Refresh now <i class="fa fa-refresh"></i></span>
     </button>
-    <button class="btn btn-outline-primary times" [ngClass]="classTime()" id="refreshMenu" ngbDropdownToggle>
-        &nbsp; <span class="times-text" [innerHTML]="getActiveRefreshTime()"></span>
+    <button class="btn btn-outline-primary times" id="refreshMenu" ngbDropdownToggle>
+        <i [ngClass]="classTime()" ></i>&nbsp; <span class="times-text" [innerHTML]="getActiveRefreshTime()"></span>
     </button>
     <div ngbDropdownMenu aria-labelledby="refreshMenu" aria-expanded="true">
         <span class="dropdown-header">Refresh times (in seconds)</span>

--- a/src/main/webapp/app/shared/refresh/refresh-selector.component.scss
+++ b/src/main/webapp/app/shared/refresh/refresh-selector.component.scss
@@ -5,7 +5,6 @@ Refresh selector styles
 .dropdown {
     .times {
         font-weight: normal;
-        line-height: 1.25;
         .times-text {
             font-family: sans-serif;
         }


### PR DESCRIPTION
This is a little UX feature I was thinking about since we have the auto reload option. I found that it is not comfortable to go into the refresh drop down every time I want to refresh manually, even if a auto-refresh is running. So I moved from this

![image](https://user-images.githubusercontent.com/2758003/48666491-5b889480-eac3-11e8-90f0-5a7a7f152f90.png)

to this

![image](https://user-images.githubusercontent.com/2758003/48666511-aa362e80-eac3-11e8-820d-3e138e2bb805.png)


- [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed

