### PR TITLE
display configured config label

### DIFF
--- a/src/main/java/io/github/jhipster/registry/config/ConfigServerConfig.java
+++ b/src/main/java/io/github/jhipster/registry/config/ConfigServerConfig.java
@@ -5,13 +5,37 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
-@ConfigurationProperties(prefix = "spring.cloud.config.server")
+@ConfigurationProperties(prefix = "spring.cloud.config")
 public class ConfigServerConfig {
 
-    private List<Map<String, Object>> composite = new ArrayList<>();
+    @NestedConfigurationProperty
+    private Server server;
 
-    public List<Map<String, Object>> getComposite() {
-        return composite;
+    private String label;
+
+    public Server getServer() {
+        return server;
+    }
+
+    public void setServer(Server server) {
+        this.server = server;
+    }
+
+    public void setLabel(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public static class Server {
+        private List<Map<String, Object>> composite = new ArrayList<>();
+
+        public List<Map<String, Object>> getComposite() {
+            return composite;
+        }
     }
 }

--- a/src/main/java/io/github/jhipster/registry/web/rest/ProfileInfoResource.java
+++ b/src/main/java/io/github/jhipster/registry/web/rest/ProfileInfoResource.java
@@ -36,7 +36,7 @@ public class ProfileInfoResource {
     public ProfileInfoVM getActiveProfiles() {
         String[] activeProfiles = DefaultProfileUtil.getActiveProfiles(env);
 
-        return new ProfileInfoVM(activeProfiles, getRibbonEnv(activeProfiles), configServerConfig.getComposite());
+        return new ProfileInfoVM(activeProfiles, getRibbonEnv(activeProfiles), configServerConfig.getServer().getComposite(), configServerConfig.getLabel());
     }
 
     private String getRibbonEnv(String[] activeProfiles) {
@@ -57,18 +57,25 @@ public class ProfileInfoResource {
 
         private String[] activeProfiles;
 
+        private String label;
+
         private String ribbonEnv;
 
         private List<Map<String, Object>> configurationSources;
 
-        ProfileInfoVM(String[] activeProfiles, String ribbonEnv, List<Map<String, Object>> configurationSources) {
+        ProfileInfoVM(String[] activeProfiles, String ribbonEnv, List<Map<String, Object>> configurationSources, String label) {
             this.activeProfiles = activeProfiles;
             this.ribbonEnv = ribbonEnv;
             this.configurationSources = configurationSources;
+            this.label = label;
         }
 
         public String[] getActiveProfiles() {
             return activeProfiles;
+        }
+
+        public String getLabel() {
+            return label;
         }
 
         public String getRibbonEnv() {

--- a/src/main/webapp/app/layouts/profiles/profile-info.model.ts
+++ b/src/main/webapp/app/layouts/profiles/profile-info.model.ts
@@ -1,5 +1,6 @@
 export class ProfileInfo {
     activeProfiles: string[];
+    label: string;
     ribbonEnv: string;
     inProduction: boolean;
     swaggerEnabled: boolean;

--- a/src/main/webapp/app/layouts/profiles/profile.service.ts
+++ b/src/main/webapp/app/layouts/profiles/profile.service.ts
@@ -19,6 +19,7 @@ export class ProfileService {
                     const data = res.body;
                     const pi = new ProfileInfo();
                     pi.activeProfiles = data.activeProfiles;
+                    pi.label = data.label;
                     pi.ribbonEnv = data.ribbonEnv;
                     pi.configurationSources = data.configurationSources;
                     pi.inProduction = data.activeProfiles.includes('prod');

--- a/src/main/webapp/app/registry/config/config.component.ts
+++ b/src/main/webapp/app/registry/config/config.component.ts
@@ -50,8 +50,10 @@ export class JhiConfigComponent implements OnInit, OnDestroy {
     load() {
         this.profileService.getProfileInfo().then((response) => {
             this.activeRegistryProfiles = response.activeProfiles;
+            this.label = response.label;
             this.isNative = this.activeRegistryProfiles.includes('native');
             this.configurationSources = response.configurationSources;
+            this.refresh();
         });
 
         this.refreshReloadSubscription = this.refreshService.refreshReload$.subscribe((empty) => this.refresh());


### PR DESCRIPTION
Displays the configured `spring.cloud.config.label` in the Spring Cloud Configuration UI.
Defaults to master. (As already configured in `bootstrap.yml` and `bootstrap-prod.yml`)

Previously `master` was hardcoded in the UI.

In one project were using different branches e.g. `test` or `production`. Thus the label is, depending on the stage, `test` or `production`.

As a result the log is full of errors along the lines of

```
[org.springframework.cloud.config.server.environment.NoSuchLabelException: No such label: master]
```

Because the UI, upon loading, does an initial request with the hardcoded `master` value.
Then the user always had to type the configured label into the input to get the actual config.

I hope this small improvement might help.

Thanks for the JHipster project and keep up the good work 👍 

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
