### PR TITLE
move oauth2 attributes to config

### DIFF
--- a/src/main/java/io/github/jhipster/registry/config/ApplicationProperties.java
+++ b/src/main/java/io/github/jhipster/registry/config/ApplicationProperties.java
@@ -12,4 +12,32 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties(prefix = "application", ignoreUnknownFields = false)
 public class ApplicationProperties {
 
+    private final Oauth2 oauth2 = new Oauth2();
+
+    public Oauth2 getOauth2() {
+        return oauth2;
+    }
+
+    public static class Oauth2 {
+
+        private String principalAttribute;
+
+        private String authoritiesAttribute;
+
+        public String getPrincipalAttribute() {
+            return principalAttribute;
+        }
+
+        public void setPrincipalAttribute(String principalAttribute) {
+            this.principalAttribute = principalAttribute;
+        }
+
+        public String getAuthoritiesAttribute() {
+            return authoritiesAttribute;
+        }
+
+        public void setAuthoritiesAttribute(String authoritiesAttribute) {
+            this.authoritiesAttribute = authoritiesAttribute;
+        }
+    }
 }

--- a/src/main/java/io/github/jhipster/registry/config/OAuth2SecurityConfiguration.java
+++ b/src/main/java/io/github/jhipster/registry/config/OAuth2SecurityConfiguration.java
@@ -26,14 +26,14 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 @Profile(Constants.PROFILE_OAUTH2)
 public class OAuth2SecurityConfiguration extends ResourceServerConfigurerAdapter {
 
-    private static final String OAUTH2_PRINCIPAL_ATTRIBUTE = "preferred_username";
-
-    private static final String OAUTH2_AUTHORITIES_ATTRIBUTE = "roles";
-
     private ResourceServerProperties resourceServerProperties;
 
-    public OAuth2SecurityConfiguration(ResourceServerProperties resourceServerProperties) {
+    private final ApplicationProperties applicationProperties;
+
+    public OAuth2SecurityConfiguration(ResourceServerProperties resourceServerProperties,
+                                       ApplicationProperties applicationProperties) {
         this.resourceServerProperties = resourceServerProperties;
+        this.applicationProperties = applicationProperties;
     }
 
     @Bean
@@ -47,12 +47,12 @@ public class OAuth2SecurityConfiguration extends ResourceServerConfigurerAdapter
 
     @Bean
     public PrincipalExtractor principalExtractor() {
-        return new SimplePrincipalExtractor(OAUTH2_PRINCIPAL_ATTRIBUTE);
+        return new SimplePrincipalExtractor(applicationProperties.getOauth2().getPrincipalAttribute());
     }
 
     @Bean
     public AuthoritiesExtractor authoritiesExtractor() {
-        return new SimpleAuthoritiesExtractor(OAUTH2_AUTHORITIES_ATTRIBUTE);
+        return new SimpleAuthoritiesExtractor(applicationProperties.getOauth2().getAuthoritiesAttribute());
     }
 
     @Bean

--- a/src/main/resources/config/application-oauth2.yml
+++ b/src/main/resources/config/application-oauth2.yml
@@ -40,3 +40,8 @@ server:
                 http-only: true
                 # custom session cookie name to prevent conflict with another application on the same domain
                 name: JSESSIONID_REGISTRY
+
+application:
+    oauth2:
+        principal-attribute: preferred_username
+        authorities-attribute: roles


### PR DESCRIPTION
Different OAuth2 servers use different attributes. This change allow to user customize attributes name for `principal` and `authorities`.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
