### PR TITLE
secure eureka/config paths for oauth2 request with auth header

### DIFF
--- a/src/main/java/io/github/jhipster/registry/config/OAuth2SecurityConfiguration.java
+++ b/src/main/java/io/github/jhipster/registry/config/OAuth2SecurityConfiguration.java
@@ -76,6 +76,8 @@ public class OAuth2SecurityConfiguration extends ResourceServerConfigurerAdapter
             .requestMatcher(authorizationHeaderRequestMatcher())
             .authorizeRequests()
             .antMatchers("/services/**").authenticated()
+            .antMatchers("/eureka/**").hasAuthority(AuthoritiesConstants.ADMIN)
+            .antMatchers("/config/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/api/profile-info").permitAll()
             .antMatchers("/api/**").authenticated()
             .antMatchers("/management/health").permitAll()


### PR DESCRIPTION
**Overview of the Issue**

If you make a request using basic auth, it adds a header like `Authorization: Basic YWRtaW46pWRtaW4=`.  There is an [OAuth2 config](https://github.com/jhipster/jhipster-registry/blob/66e30324d479b8f2c6c6070f12dcf298b633ff4c/src/main/java/io/github/jhipster/registry/config/OAuth2SecurityConfiguration.java#L58-L83) that is used when there is an `Authorization` header, and in that config the `/eureka` and `/config` paths are not secured.  A plain request won't be able to access the endpoints, but one using any basic auth credentials works.

**Steps to Reproduce**
Start the registry with the `oauth2` profile (I just add it in `bootstrap.yml`)
`curl -v http://this-should:not-work@localhost:8761/eureka/apps`

Originally reported here: https://stackoverflow.com/questions/54653352/jhipster-registry-with-oauth2-eureka-and-config-endpoints-unsecured

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
