### PR TITLE
Enable CORS on eureka endpoints

### DIFF
--- a/src/main/java/io/github/jhipster/registry/config/JWTSecurityConfiguration.java
+++ b/src/main/java/io/github/jhipster/registry/config/JWTSecurityConfiguration.java
@@ -94,7 +94,6 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     public void configure(WebSecurity web) throws Exception {
         web.ignoring()
-            .antMatchers(HttpMethod.OPTIONS, "/**")
             .antMatchers("/app/**/*.{js,html}")
             .antMatchers("/swagger-ui/**")
             .antMatchers("/content/**");
@@ -103,6 +102,8 @@ public class JWTSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
+            .cors()
+        .and()
             .exceptionHandling()
             .authenticationEntryPoint(authenticationEntryPoint)
         .and()

--- a/src/main/java/io/github/jhipster/registry/config/OAuth2SecurityConfiguration.java
+++ b/src/main/java/io/github/jhipster/registry/config/OAuth2SecurityConfiguration.java
@@ -64,6 +64,8 @@ public class OAuth2SecurityConfiguration extends ResourceServerConfigurerAdapter
     @Override
     public void configure(HttpSecurity http) throws Exception {
         http
+            .cors()
+        .and()
             .csrf()
             .disable()
             .headers()

--- a/src/main/java/io/github/jhipster/registry/config/OAuth2SsoConfiguration.java
+++ b/src/main/java/io/github/jhipster/registry/config/OAuth2SsoConfiguration.java
@@ -25,6 +25,8 @@ public class OAuth2SsoConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http
+            .cors()
+        .and()
             .csrf()
             .disable()
             .headers()

--- a/src/main/java/io/github/jhipster/registry/config/WebConfigurer.java
+++ b/src/main/java/io/github/jhipster/registry/config/WebConfigurer.java
@@ -151,6 +151,9 @@ public class WebConfigurer implements ServletContextInitializer, WebServerFactor
             source.registerCorsConfiguration("/v2/api-docs", config);
             source.registerCorsConfiguration("/*/api/**", config);
         }
+
+        // default is to deny all CORS requests
+        source.registerCorsConfiguration("/**", new CorsConfiguration());
         return new CorsFilter(source);
     }
 

--- a/src/main/java/io/github/jhipster/registry/config/WebConfigurer.java
+++ b/src/main/java/io/github/jhipster/registry/config/WebConfigurer.java
@@ -6,8 +6,6 @@ import io.github.jhipster.web.filter.CachingHttpHeadersFilter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.web.embedded.undertow.UndertowServletWebServer;
 import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
 import org.springframework.boot.web.server.*;
 import io.undertow.UndertowOptions;
@@ -148,6 +146,7 @@ public class WebConfigurer implements ServletContextInitializer, WebServerFactor
         CorsConfiguration config = jHipsterProperties.getCors();
         if (config.getAllowedOrigins() != null && !config.getAllowedOrigins().isEmpty()) {
             log.debug("Registering CORS filter");
+            source.registerCorsConfiguration("/eureka/**", config);
             source.registerCorsConfiguration("/api/**", config);
             source.registerCorsConfiguration("/v2/api-docs", config);
             source.registerCorsConfiguration("/*/api/**", config);


### PR DESCRIPTION
- Fix #246 
- Tested with dummy client and fix seems to work.
- Configure fallback URL with default deny all CORS configuration. This would guard against any URL not explicitly allowed and pre-flight requests would correctly receive 403 status with 'Invalid CORS request' as response

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
