### PR TITLE
Update app.json to 5.0.2 jhipster registry version

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,7 +17,7 @@
     },
     "JHIPSTER_REGISTRY_VERSION": {
       "description": "Version of the registry to deploy.",
-      "value": "4.1.1"
+      "value": "5.0.2"
     }
   },
   "buildpacks": [


### PR DESCRIPTION
This environment variable is used by the Heroku buildpack that downloads a pre-compiled version of the registry. According to this repo's [Releases](https://github.com/jhipster/jhipster-registry/releases), 5.0.2 is the latest.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
