### PR TITLE
Add GCP Deploy Button (using Cloud Run) to Readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM openjdk:8-jre-alpine
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
     JAVA_OPTS="" \
     SPRING_PROFILES_ACTIVE=prod
-EXPOSE 8761
+EXPOSE ${PORT}
 RUN apk add --no-cache curl && \
     mkdir /target && \
     chmod g+rwx /target

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ There are a few limitations when deploying to Heroku.
 * The registry will only work with [native configuration](https://www.jhipster.tech/jhipster-registry/#spring-cloud-config) (and not Git config).
 * The registry service cannot be scaled up to multiple dynos to provide redundancy. You must deploy multiple applications (i.e. click the button more than once). This is because Eureka requires distinct URLs to synchronize in-memory state between instances.
 
+## Deploy to Google Cloud Platform (GCP)
+
+Click the below button to deploy your own instance of the JHipster Registry to GCP:
+
+[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run)
+
 ## Running locally
 
 To run the cloned repository;

--- a/app.json
+++ b/app.json
@@ -21,7 +21,7 @@
     },
     "PORT": {
       "description": "Port to listen on",
-      "value": 8761
+      "value": "8761"
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -5,7 +5,7 @@
   "env": {
     "JHIPSTER_PASSWORD": {
       "description": "Admin password for the registry (used to login after clicking 'View App'). Must be at least 5 characters.",
-      "required": "true"
+      "required": true
     },
     "JAVA_OPTS": {
       "description": "Java runtime options.",

--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "name": "JHipster Registry",
+  "name": "jhipster-registry",
   "description": "This is the JHipster registry service, based on Spring Cloud Netflix, Eureka and Spring Cloud Config.",
   "logo": "https://www.jhipster.tech/images/logo/logo-jhipster-drink-coffee.png",
   "env": {

--- a/app.json
+++ b/app.json
@@ -18,10 +18,6 @@
     "JHIPSTER_REGISTRY_VERSION": {
       "description": "Version of the registry to deploy.",
       "value": "5.0.2"
-    },
-    "PORT": {
-      "description": "Port to listen on",
-      "value": "8761"
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -18,6 +18,10 @@
     "JHIPSTER_REGISTRY_VERSION": {
       "description": "Version of the registry to deploy.",
       "value": "5.0.2"
+    },
+    "PORT": {
+      "description": "Port to listen on",
+      "value": 8761
     }
   }
 }

--- a/app.json
+++ b/app.json
@@ -19,9 +19,5 @@
       "description": "Version of the registry to deploy.",
       "value": "5.0.2"
     }
-  },
-  "buildpacks": [
-    {"url": "heroku/jvm"},
-    {"url": "https://github.com/jhipster/jhipster-registry-buildpack"}
-  ]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5767,12 +5767,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5787,17 +5789,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5914,7 +5919,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5926,6 +5932,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5940,6 +5947,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5947,12 +5955,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5971,6 +5981,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6051,7 +6062,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6063,6 +6075,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6184,6 +6197,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5767,14 +5767,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5789,20 +5787,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5919,8 +5914,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5932,7 +5926,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5947,7 +5940,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5955,14 +5947,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5981,7 +5971,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6062,8 +6051,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6075,7 +6063,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6197,7 +6184,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/main/resources/config/application-prod.yml
+++ b/src/main/resources/config/application-prod.yml
@@ -48,7 +48,7 @@ spring:
 #        keyAlias: JHipsterRegistry
 # ===================================================================
 server:
-    port: 8761
+    port: ${PORT}
     compression:
         enabled: true
         mime-types: text/html,text/xml,text/plain,text/css, application/javascript, application/json


### PR DESCRIPTION
Working on https://github.com/jhipster/generator-jhipster/issues/10345, I thought it would be beneficial to add a deploy button to GCP, similar to what we have for Heroku. Especially this will help with the microservice deployments on GCP.  

Will finalize the PR once my testing is done :smile: 

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
