### PR TITLE
Add Google Cloud Run Button

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ There are a few limitations when deploying to Heroku.
 * The registry will only work with [native configuration](https://www.jhipster.tech/jhipster-registry/#spring-cloud-config) (and not Git config).
 * The registry service cannot be scaled up to multiple dynos to provide redundancy. You must deploy multiple applications (i.e. click the button more than once). This is because Eureka requires distinct URLs to synchronize in-memory state between instances.
 
+## Deploy to Google Cloud Platform (GCP)
+
+Click the below button to deploy your own instance of the JHipster Registry to GCP:
+
+[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run)
+
 ## Running locally
 
 To run the cloned repository;


### PR DESCRIPTION
This adds the [google cloud run button](https://github.com/GoogleCloudPlatform/cloud-run-button#add-the-cloud-run-button-to-your-repos-readme)

Fixes #398

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
