### PR TITLE
Fix enable-self-preservation flag in replica documentation

### DIFF
--- a/src/main/webapp/app/registry/replicas/replicas.component.html
+++ b/src/main/webapp/app/registry/replicas/replicas.component.html
@@ -99,7 +99,7 @@ eureka:
     instance:
         hostname: eureka-peer-1
     server:
-        enable-self-preservation: true
+        enable-self-preservation: false
         registry-sync-retry-wait-ms: 500
         a-sgcache-expiry-timeout-ms: 60000
         eviction-interval-timer-in-ms: 30000
@@ -120,7 +120,7 @@ eureka:
     instance:
         hostname: eureka-peer-2
     server:
-        enable-self-preservation: true
+        enable-self-preservation: false
         registry-sync-retry-wait-ms: 500
         a-sgcache-expiry-timeout-ms: 60000
         eviction-interval-timer-in-ms: 30000


### PR DESCRIPTION
I'm changing the eureka.server.enable-self-preservation to false in replica documentation in order to reflect the values in the different application YML files.

Fix jhipster/jhipster-registry/issues/426