### PR TITLE
fix encrypt response parsing

### DIFF
--- a/src/main/webapp/app/registry/encryption/encryption.service.ts
+++ b/src/main/webapp/app/registry/encryption/encryption.service.ts
@@ -8,10 +8,10 @@ export class EncryptionService {
   constructor(private http: HttpClient) {}
 
   encrypt(textToEncrypt: string): Observable<string> {
-    return this.http.post<string>('config/encrypt', textToEncrypt).pipe(map((response: string) => '{cipher}' + response));
+    return this.http.post('config/encrypt', textToEncrypt, { responseType: 'text' }).pipe(map((response: string) => '{cipher}' + response));
   }
 
   decrypt(textToDecrypt: string): Observable<string> {
-    return this.http.post<string>('config/decrypt', textToDecrypt);
+    return this.http.post('config/decrypt', textToDecrypt, { responseType: 'text' });
   }
 }

--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -21,6 +21,7 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
             context: [
                 '/api',
                 '/services',
+                '/config',
                 '/management',
                 '/swagger-resources',
                 '/v2/api-docs',


### PR DESCRIPTION
Fix #434 by setting `responseType` to `text`, otherwise it fails when trying to parse the simple string as JSON.

Typescript complains when the response is typed and responseType is `text`, so I removed `<string>` from the service methods.  Related StackOverflow: https://stackoverflow.com/q/49771603/3737815

Also added `/config` to the webpack paths so the request can be tested in the `dev` profile.

Related links:
https://angular.io/guide/http#requesting-non-json-data

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
