### PR TITLE
Update Heroku deployment to start with Java 11

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,7 @@
     },
     "JAVA_OPTS": {
       "description": "Java runtime options.",
-      "value": "-Xmx300m -Xss512k -XX:CICompilerCount=2 -XX:ReservedCodeCacheSize=50m -XX:MaxMetaspaceSize=80m -XX:ParallelGCThreads=3 -Dfile.encoding=UTF-8"
+      "value": "-Dfile.encoding=UTF-8"
     },
     "SPRING_OPTS": {
       "description": "Spring Boot options.",
@@ -17,11 +17,8 @@
     },
     "JHIPSTER_REGISTRY_VERSION": {
       "description": "Version of the registry to deploy.",
-      "value": "5.0.2"
+      "value": "6.2.0"
     }
   },
-  "buildpacks": [
-    {"url": "heroku/jvm"},
-    {"url": "https://github.com/jhipster/jhipster-registry-buildpack"}
-  ]
+  "buildpacks": [{ "url": "heroku/jvm" }, { "url": "https://github.com/jhipster/jhipster-registry-buildpack" }]
 }

--- a/system.properties
+++ b/system.properties
@@ -1,0 +1,1 @@
+java.runtime.version=11


### PR DESCRIPTION
This updates the Heroku button to start with Java 11 and also use the jhipster_registry version 6.2.0 as default.

Fixes https://github.com/jhipster/jhipster-registry/issues/467

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
