### PR TITLE
Update Dockerfile to support building image on Win

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ ADD . /code/
 RUN \
     apt-get update && \
     apt-get install build-essential -y && \
+    apt-get install dos2unix -y && \
     cd /code/ && \
+    dos2unix mvnw && \
     rm -Rf target node_modules && \
     chmod +x /code/mvnw && \
     sleep 1 && \


### PR DESCRIPTION
On Windows 10 you get an error while building the image: /bin/sh: 1: ./mvnw: not found
Using dos2unix to replace \r\n with \n solves the problem for Windows

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/master/CONTRIBUTING.md) are followed
