### PR TITLE
Update Undertow to fix CVE-2020-10687

### DIFF
--- a/.yo-rc.json
+++ b/.yo-rc.json
@@ -1,6 +1,6 @@
 {
   "generator-jhipster": {
-    "jhipsterVersion": "6.10.4",
+    "jhipsterVersion": "6.10.5",
     "baseName": "JHipsterRegistry",
     "packageName": "io.github.jhipster.registry",
     "packageFolder": "io/github/jhipster/registry",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9853,9 +9853,9 @@
       }
     },
     "generator-jhipster": {
-      "version": "6.10.4",
-      "resolved": "https://registry.npmjs.org/generator-jhipster/-/generator-jhipster-6.10.4.tgz",
-      "integrity": "sha512-AuPNTXucH8ekryRtVbiX+EC64jIHozxq7A+hTC/rhEgQyaMMqish+CpPGYaNLgzT2oqAvXFLWFndsiBJ4YdjVw==",
+      "version": "6.10.5",
+      "resolved": "https://registry.npmjs.org/generator-jhipster/-/generator-jhipster-6.10.5.tgz",
+      "integrity": "sha512-5NulSuou7sghjggc1rQuWWWigfJAdlzB0iMB92WQd90nXBC9ZopVFvgkjfLxWpKEgidFPjrwhrt5iWjoA+yo5A==",
       "dev": true,
       "requires": {
         "aws-sdk": "2.706.0",
@@ -17842,9 +17842,9 @@
           }
         },
         "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-loader": "4.0.2",
     "file-loader": "6.0.0",
     "friendly-errors-webpack-plugin": "1.7.0",
-    "generator-jhipster": "6.10.4",
+    "generator-jhipster": "6.10.5",
     "html-loader": "1.1.0",
     "html-webpack-plugin": "4.3.0",
     "husky": "4.2.5",

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         <profile.tls />
 
         <!-- Dependency versions -->
-        <jhipster-dependencies.version>3.9.0</jhipster-dependencies.version>
+        <jhipster-dependencies.version>3.9.1</jhipster-dependencies.version>
         <!-- The spring-boot version should match the one managed by
         https://mvnrepository.com/artifact/io.github.jhipster/jhipster-dependencies/${jhipster-dependencies.version} -->
         <spring-boot.version>2.2.7.RELEASE</spring-boot.version>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -25,9 +25,9 @@ sonar.issue.ignore.multicriteria.UndocumentedApi.ruleKey=squid:UndocumentedApi
 # Rule https://sonarcloud.io/coding_rules?open=squid%3AS4502&rule_key=squid%3AS4502 is ignored, as for JWT tokens we are not subject to CSRF attack
 sonar.issue.ignore.multicriteria.S4502.resourceKey=src/main/java/**/*
 sonar.issue.ignore.multicriteria.S4502.ruleKey=squid:S4502
-# Rule https://sonarcloud.io/coding_rules?open=squid%3AS4684&rule_key=squid%3AS4684
+# Rule https://sonarcloud.io/coding_rules?open=java%3AS4684&rule_key=java%3AS4684
 sonar.issue.ignore.multicriteria.S4684.resourceKey=src/main/java/**/*
-sonar.issue.ignore.multicriteria.S4684.ruleKey=squid:S4684
+sonar.issue.ignore.multicriteria.S4684.ruleKey=java:S4684
 # Rule https://sonarcloud.io/coding_rules?open=Web%3ABoldAndItalicTagsCheck&rule_key=Web%3ABoldAndItalicTagsCheck is ignored. Even if we agree that using the "i" tag is an awful practice, this is what is recommended by http://fontawesome.io/examples/
 sonar.issue.ignore.multicriteria.BoldAndItalicTagsCheck.resourceKey=src/main/webapp/app/**/*.*
 sonar.issue.ignore.multicriteria.BoldAndItalicTagsCheck.ruleKey=Web:BoldAndItalicTagsCheck


### PR DESCRIPTION
Related to jhipster/jhipster#906

An important security vulnerabilities was discovered in all versions of Undertow before Undertow 2.2.0.Final. JHipster release v6.10.5 fixes this security vulnerabilities.

https://www.jhipster.tech/2020/11/07/jhipster-release-6.10.5.html
https://nvd.nist.gov/vuln/detail/CVE-2020-10687

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/main/CONTRIBUTING.md) are followed
