### PR TITLE
align app.json version with latest release

### DIFF
--- a/app.json
+++ b/app.json
@@ -17,7 +17,7 @@
     },
     "JHIPSTER_REGISTRY_VERSION": {
       "description": "Version of the registry to deploy.",
-      "value": "6.4.0"
+      "value": "6.5.0"
     }
   },
   "buildpacks": [{ "url": "heroku/jvm" }, { "url": "https://github.com/jhipster/jhipster-registry-buildpack" }]


### PR DESCRIPTION
Fixes the Heroku deploy button.

In v6.4.0 it was broken because [the release](https://github.com/jhipster/jhipster-registry/releases/tag/v6.4.0) did not contain a JAR file (related issue https://github.com/jhipster/jhipster-registry/issues/490).

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/main/CONTRIBUTING.md) are followed
