### PR TITLE
allow /api/account and /api/logout for any authenticated users

### DIFF
--- a/src/main/java/io/github/jhipster/registry/config/OAuth2SecurityConfiguration.java
+++ b/src/main/java/io/github/jhipster/registry/config/OAuth2SecurityConfiguration.java
@@ -102,6 +102,8 @@ public class OAuth2SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/services/**").authenticated()
             .antMatchers("/eureka/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/config/**").hasAuthority(AuthoritiesConstants.ADMIN)
+            .antMatchers("/api/account").authenticated()
+            .antMatchers("/api/logout").authenticated()
             .antMatchers("/api/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/management/info").permitAll()
             .antMatchers("/management/health").permitAll()


### PR DESCRIPTION
- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/main/CONTRIBUTING.md) are followed

This PR allows all users to call /api/account and /api/logout without an admin role. Without these settings, there will be an infinite loop, when using oauth2

Fixes #473 