### PR TITLE
Add arm64 image to docker.

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -18,7 +18,9 @@
 #
 
 name: Publish Containers
-on: [push]
+on:
+  push:
+    branches: [main]
 jobs:
     pipeline:
         name: JHipster Registry Docker
@@ -38,7 +40,7 @@ jobs:
               # This is where you will update the PAT to GITHUB_TOKEN
               run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             - name: Publish to GitHub Container Registry
-              run: ./mvnw -ntp verify -DskipTests -Pprod jib:build -Dimage=ghcr.io/${{ github.actor }}/jhipster-registry:ci
+              run: ./mvnw -ntp verify -DskipTests -Pprod jib:build -Dimage=ghcr.io/${{ github.actor }}/jhipster-registry:main
             - name: 'DOCKER: list image'
               run: docker images
             - name: 'DOCKER: start container'

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -32,7 +32,7 @@ jobs:
             - name: 'Setup java'
               uses: actions/setup-java@v2
               with:
-                  distribution: 'adopt'
+                  distribution: 'temurin'
                   java-version: '11'
             - name: 'TOOLS: docker version'
               run: docker version

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -38,7 +38,7 @@ jobs:
               # This is where you will update the PAT to GITHUB_TOKEN
               run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             - name: Publish to GitHub Container Registry
-              run: mvn -ntp verify -DskipTests -Pprod jib:build -Dimage=ghcr.io/${{ github.actor }}/jhipster-registry:ci
+              run: ./mvnw -ntp verify -DskipTests -Pprod jib:build -Dimage=ghcr.io/${{ github.actor }}/jhipster-registry:ci
             - name: 'DOCKER: list image'
               run: docker images
             - name: 'DOCKER: start container'

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,0 +1,53 @@
+#
+# Copyright 2015-2021 the original author or authors from the JHipster project.
+#
+# This file is part of the JHipster project, see https://www.jhipster.tech/
+# for more information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Publish Containers
+on: [push]
+jobs:
+    pipeline:
+        name: JHipster Registry Docker
+        runs-on: ubuntu-latest
+        if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]')"
+        timeout-minutes: 40
+        steps:
+            - uses: actions/checkout@v2
+            - name: 'Setup java'
+              uses: actions/setup-java@v2
+              with:
+                  distribution: 'adopt'
+                  java-version: '11'
+            - name: 'TOOLS: docker version'
+              run: docker version
+            - name: Log in to registry
+              # This is where you will update the PAT to GITHUB_TOKEN
+              run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            - name: Publish to GitHub Container Registry
+              run: mvn -ntp verify -DskipTests -Pprod jib:build -Dimage=ghcr.io/${{ github.actor }}/jhipster-registry:ci
+            - name: 'DOCKER: list image'
+              run: docker images
+            - name: 'DOCKER: start container'
+              run: docker run --name jhipster-registry -p 8761:8761 -d -t -e JHIPSTER_SECURITY_AUTHENTICATION_JWT_BASE64_SECRET='bXktc2VjcmV0LWtleS13aGljaC1zaG91bGQtYmUtY2hhbmdlZC1pbi1wcm9kdWN0aW9uLWFuZC1iZS1iYXNlNjQtZW5jb2RlZAo=' ghcr.io/${{ github.actor }}/jhipster-registry:ci
+            - name: 'DOCKER: wait 30sec'
+              run: sleep 30
+            - name: 'DOCKER list containers'
+              run: docker container ps -a
+            - name: 'DOCKER: see logs'
+              run: docker container logs jhipster-registry
+            - name: 'DOCKER: curl 8761'
+              run: curl -v http://localhost:8761

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -34,17 +34,20 @@ jobs:
               with:
                   distribution: 'temurin'
                   java-version: '11'
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v1
+              with:
+                registry: ghcr.io
+                username: ${{ github.repository_owner }}
+                password: ${{ secrets.GITHUB_TOKEN }}
             - name: 'TOOLS: docker version'
               run: docker version
-            - name: Log in to registry
-              # This is where you will update the PAT to GITHUB_TOKEN
-              run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             - name: Publish to GitHub Container Registry
-              run: ./mvnw -ntp verify -DskipTests -Pprod jib:build -Dimage=ghcr.io/${{ github.actor }}/jhipster-registry:main
+              run: ./mvnw -ntp verify -DskipTests -Pprod jib:build -Dimage=ghcr.io/${{ github.repository }}:main
             - name: 'DOCKER: list image'
               run: docker images
             - name: 'DOCKER: start container'
-              run: docker run --name jhipster-registry -p 8761:8761 -d -t -e JHIPSTER_SECURITY_AUTHENTICATION_JWT_BASE64_SECRET='bXktc2VjcmV0LWtleS13aGljaC1zaG91bGQtYmUtY2hhbmdlZC1pbi1wcm9kdWN0aW9uLWFuZC1iZS1iYXNlNjQtZW5jb2RlZAo=' ghcr.io/${{ github.actor }}/jhipster-registry:ci
+              run: docker run --name jhipster-registry -p 8761:8761 -d -t -e JHIPSTER_SECURITY_AUTHENTICATION_JWT_BASE64_SECRET='bXktc2VjcmV0LWtleS13aGljaC1zaG91bGQtYmUtY2hhbmdlZC1pbi1wcm9kdWN0aW9uLWFuZC1iZS1iYXNlNjQtZW5jb2RlZAo=' ghcr.io/${{ github.repository }}:main
             - name: 'DOCKER: wait 30sec'
               run: sleep 30
             - name: 'DOCKER list containers'

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "jhipster-registry",
       "version": "7.0.0",
       "license": "UNLICENSED",
       "dependencies": {

--- a/pom.xml
+++ b/pom.xml
@@ -543,11 +543,7 @@
                             </pluginExtension>
                         </pluginExtensions>
                         <from>
-                            <!-- Enable once eclipse-temurin:11-jre-focal is build for arm64
-                                 https://hub.docker.com/_/eclipse-temurin?tab=description
                             <image>eclipse-temurin:11-jre</image>
-                            -->
-                            <image>adoptopenjdk:11-jre-hotspot</image>
                             <platforms>
                                 <platform>
                                     <architecture>amd64</architecture>

--- a/pom.xml
+++ b/pom.xml
@@ -521,9 +521,43 @@
                     <groupId>com.google.cloud.tools</groupId>
                     <artifactId>jib-maven-plugin</artifactId>
                     <version>${jib-maven-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                          <groupId>com.google.cloud.tools</groupId>
+                          <artifactId>jib-ownership-extension-maven</artifactId>
+                          <version>0.1.0</version>
+                        </dependency>
+                      </dependencies>
                     <configuration>
+                        <pluginExtensions>
+                            <pluginExtension>
+                                <implementation>com.google.cloud.tools.jib.maven.extension.ownership.JibOwnershipExtension</implementation>
+                                <configuration implementation="com.google.cloud.tools.jib.maven.extension.ownership.Configuration">
+                                    <rules>
+                                        <rule>
+                                            <glob>/target</glob>
+                                            <ownership>1000</ownership>
+                                        </rule>
+                                    </rules>
+                                </configuration>
+                            </pluginExtension>
+                        </pluginExtensions>
                         <from>
+                            <!-- Enable once eclipse-temurin:11-jre-focal is build for arm64
+                                 https://hub.docker.com/_/eclipse-temurin?tab=description
+                            <image>eclipse-temurin:11-jre</image>
+                            -->
                             <image>adoptopenjdk:11-jre-hotspot</image>
+                            <platforms>
+                                <platform>
+                                    <architecture>amd64</architecture>
+                                    <os>linux</os>
+                                </platform>
+                                <platform>
+                                    <architecture>arm64</architecture>
+                                    <os>linux</os>
+                                </platform>
+                            </platforms>
                         </from>
                         <to>
                             <image>jhipster-registry:latest</image>

--- a/src/main/docker/jib/entrypoint.sh
+++ b/src/main/docker/jib/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-echo "The application will start in ${JHIPSTER_SLEEP}s..." && sleep ${JHIPSTER_SLEEP}
+echo "The JHipster Registry will start in ${JHIPSTER_SLEEP}s..." && sleep ${JHIPSTER_SLEEP}
 exec java ${JAVA_OPTS} -noverify -XX:+AlwaysPreTouch -Djava.security.egd=file:/dev/./urandom -cp /app/resources/:/app/classes/:/app/libs/* "tech.jhipster.registry.JHipsterRegistryApp"  "$@"


### PR DESCRIPTION
- Fix jib plugin by creating a target folder (for logs) and changing ownership.
- Add additional arm64 platform.
- Add workflow that publishes both images (arm64/amd64) to GitHub containers.

Related to https://github.com/jhipster/jhipster-registry/issues/500

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/main/CONTRIBUTING.md) are followed
