### PR TITLE
Drop on disk logging.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -521,27 +521,7 @@
                     <groupId>com.google.cloud.tools</groupId>
                     <artifactId>jib-maven-plugin</artifactId>
                     <version>${jib-maven-plugin.version}</version>
-                    <dependencies>
-                        <dependency>
-                          <groupId>com.google.cloud.tools</groupId>
-                          <artifactId>jib-ownership-extension-maven</artifactId>
-                          <version>0.1.0</version>
-                        </dependency>
-                      </dependencies>
                     <configuration>
-                        <pluginExtensions>
-                            <pluginExtension>
-                                <implementation>com.google.cloud.tools.jib.maven.extension.ownership.JibOwnershipExtension</implementation>
-                                <configuration implementation="com.google.cloud.tools.jib.maven.extension.ownership.Configuration">
-                                    <rules>
-                                        <rule>
-                                            <glob>/target</glob>
-                                            <ownership>1000</ownership>
-                                        </rule>
-                                    </rules>
-                                </configuration>
-                            </pluginExtension>
-                        </pluginExtensions>
                         <from>
                             <image>eclipse-temurin:11-jre</image>
                             <platforms>
@@ -588,10 +568,6 @@
                                 <permission>
                                     <file>/entrypoint.sh</file>
                                     <mode>755</mode>
-                                </permission>
-                                <permission>
-                                    <file>/target</file>
-                                    <mode>775</mode>
                                 </permission>
                             </permissions>
                         </extraDirectories>

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -105,10 +105,6 @@ spring:
   thymeleaf:
     mode: HTML
 
-logging:
-  file:
-    name: target/jhipster-registry.log
-
 server:
   port: 8761
   servlet:


### PR DESCRIPTION
Drop the need of /target folder.
Writing to docker image is not recommended.

Is there any other reason for this log?

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/jhipster-registry/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/jhipster-registry/blob/main/CONTRIBUTING.md) are followed
