### PR TITLE
Update License to 2022

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2021 the original author or authors from the JHipster project.
+# Copyright 2015-2022 the original author or authors from the JHipster project.
 #
 # This file is part of the JHipster project, see https://www.jhipster.tech/
 # for more information.

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,5 +1,5 @@
 #
-# Copyright 2015-2021 the original author or authors from the JHipster project.
+# Copyright 2015-2022 the original author or authors from the JHipster project.
 #
 # This file is part of the JHipster project, see https://www.jhipster.tech/
 # for more information.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 
-    Copyright 2015-2021 the original author or authors from the JHipster project
+    Copyright 2015-2022 the original author or authors from the JHipster project
 
                                  Apache License
                            Version 2.0, January 2004

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 JHipster
-Copyright 2015-2021 the original author or authors from the JHipster project.
+Copyright 2015-2022 the original author or authors from the JHipster project.
 
 For more information on the JHipster project, see https://www.jhipster.tech/


### PR DESCRIPTION
- related to https://github.com/jhipster/generator-jhipster/issues/17509