### PR TITLE
feat: support Consul and Kubernetes discovery backends (#320)

### DIFF
--- a/DISCOVERY_BACKEND.md
+++ b/DISCOVERY_BACKEND.md
@@ -1,0 +1,78 @@
+# Discovery Backend Configuration
+
+JHipster Registry supports multiple service discovery backends:
+
+## Eureka (Default)
+
+No additional configuration needed. Eureka is the default backend.
+
+```yaml
+application:
+  discovery:
+    backend: eureka
+```
+
+## Consul
+
+Run with the `consul` Spring profile:
+
+```bash
+java -jar jhipster-registry.jar --spring.profiles.active=consul
+```
+
+Or configure manually:
+
+```yaml
+application:
+  discovery:
+    backend: consul
+  consul:
+    host: localhost
+    port: 8500
+```
+
+### Consul Dependencies
+
+The Consul client is included when the `consul` profile is active. Make sure Consul agent is running:
+
+```bash
+consul agent -dev
+```
+
+## Kubernetes
+
+Run with the `kubernetes` Spring profile:
+
+```bash
+java -jar jhipster-registry.jar --spring.profiles.active=kubernetes
+```
+
+Or configure manually:
+
+```yaml
+application:
+  discovery:
+    backend: kubernetes
+  kubernetes:
+    namespace: default
+```
+
+### Kubernetes Requirements
+
+- The registry must be running inside a Kubernetes cluster
+- ServiceAccount with appropriate RBAC permissions is required
+- The Kubernetes Java client is included when the `kubernetes` profile is active
+
+## API Endpoints
+
+All discovery backends expose the same API:
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/discovery/applications` | List all registered applications |
+| `GET /api/discovery/status` | Get discovery backend status |
+| `GET /api/discovery/replicas` | List replica nodes |
+| `GET /api/discovery/lastn` | Get recent registrations/cancellations |
+| `GET /api/discovery/backend` | Get current backend type |
+
+Legacy Eureka endpoints (`/api/eureka/*`) continue to work and delegate to the active discovery backend.

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,8 @@
         <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
         <!-- jhipster-needle-maven-property -->
         <spring-cloud.version>2021.0.8</spring-cloud.version>
+            <consul-api.version>1.4.5</consul-api.version>
+        <kubernetes-client.version>20.0.0</kubernetes-client.version>
     </properties>
 
     <dependencyManagement>
@@ -762,13 +764,17 @@
             <id>api-docs</id>
             <properties>
                 <profile.api-docs>,api-docs</profile.api-docs>
-            </properties>
+                    <consul-api.version>1.4.5</consul-api.version>
+        <kubernetes-client.version>20.0.0</kubernetes-client.version>
+    </properties>
         </profile>
         <profile>
             <id>tls</id>
             <properties>
                 <profile.tls>,tls</profile.tls>
-            </properties>
+                    <consul-api.version>1.4.5</consul-api.version>
+        <kubernetes-client.version>20.0.0</kubernetes-client.version>
+    </properties>
         </profile>
         <profile>
             <id>webapp</id>
@@ -896,7 +902,9 @@
             <properties>
                 <!-- default Spring profiles -->
                 <spring.profiles.active>dev</spring.profiles.active>
-            </properties>
+                    <consul-api.version>1.4.5</consul-api.version>
+        <kubernetes-client.version>20.0.0</kubernetes-client.version>
+    </properties>
         </profile>
         <profile>
             <id>dev</id>
@@ -950,7 +958,9 @@
             <properties>
                 <!-- default Spring profiles -->
                 <spring.profiles.active>dev${profile.tls}</spring.profiles.active>
-            </properties>
+                    <consul-api.version>1.4.5</consul-api.version>
+        <kubernetes-client.version>20.0.0</kubernetes-client.version>
+    </properties>
         </profile>
         <profile>
             <id>prod</id>
@@ -1068,7 +1078,9 @@
             <properties>
                 <!-- default Spring profiles -->
                 <spring.profiles.active>prod${profile.api-docs}${profile.tls}${profile.e2e}</spring.profiles.active>
-            </properties>
+                    <consul-api.version>1.4.5</consul-api.version>
+        <kubernetes-client.version>20.0.0</kubernetes-client.version>
+    </properties>
         </profile>
         <profile>
             <id>war</id>
@@ -1226,7 +1238,9 @@
             <id>prod-gae</id>
             <properties>
                 <spring.profiles.active>prod${profile.api-docs},prod-gae</spring.profiles.active>
-            </properties>
+                    <consul-api.version>1.4.5</consul-api.version>
+        <kubernetes-client.version>20.0.0</kubernetes-client.version>
+    </properties>
         </profile>
         <profile>
             <id>gae</id>

--- a/src/main/java/tech/jhipster/registry/config/ApplicationProperties.java
+++ b/src/main/java/tech/jhipster/registry/config/ApplicationProperties.java
@@ -2,12 +2,6 @@ package tech.jhipster.registry.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
-/**
- * Properties specific to JHipster.
- *
- * Properties are configured in the {@code application.yml} file.
- * See {@link tech.jhipster.config.JHipsterProperties} for a good example.
- */
 @ConfigurationProperties(prefix = "application", ignoreUnknownFields = false)
 public class ApplicationProperties {
 
@@ -15,12 +9,30 @@ public class ApplicationProperties {
 
     private final Eureka eureka = new Eureka();
 
+    private final Consul consul = new Consul();
+
+    private final Kubernetes kubernetes = new Kubernetes();
+
+    private final Discovery discovery = new Discovery();
+
     public Oauth2 getOauth2() {
         return oauth2;
     }
 
     public Eureka getEureka() {
         return eureka;
+    }
+
+    public Consul getConsul() {
+        return consul;
+    }
+
+    public Kubernetes getKubernetes() {
+        return kubernetes;
+    }
+
+    public Discovery getDiscovery() {
+        return discovery;
     }
 
     public static class Oauth2 {
@@ -66,6 +78,55 @@ public class ApplicationProperties {
 
         public void setEnvironment(String environment) {
             this.environment = environment;
+        }
+    }
+
+    public static class Consul {
+
+        private String host = "localhost";
+
+        private int port = 8500;
+
+        public String getHost() {
+            return host;
+        }
+
+        public void setHost(String host) {
+            this.host = host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+        public void setPort(int port) {
+            this.port = port;
+        }
+    }
+
+    public static class Kubernetes {
+
+        private String namespace = "default";
+
+        public String getNamespace() {
+            return namespace;
+        }
+
+        public void setNamespace(String namespace) {
+            this.namespace = namespace;
+        }
+    }
+
+    public static class Discovery {
+
+        private String backend = "eureka";
+
+        public String getBackend() {
+            return backend;
+        }
+
+        public void setBackend(String backend) {
+            this.backend = backend;
         }
     }
 }

--- a/src/main/java/tech/jhipster/registry/config/EurekaServerConditionalConfiguration.java
+++ b/src/main/java/tech/jhipster/registry/config/EurekaServerConditionalConfiguration.java
@@ -1,0 +1,11 @@
+package tech.jhipster.registry.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableEurekaServer
+@ConditionalOnProperty(name = "application.discovery.backend", havingValue = "eureka", matchIfMissing = true)
+public class EurekaServerConditionalConfiguration {
+}

--- a/src/main/java/tech/jhipster/registry/service/discovery/ConsulDiscoveryService.java
+++ b/src/main/java/tech/jhipster/registry/service/discovery/ConsulDiscoveryService.java
@@ -1,0 +1,115 @@
+package tech.jhipster.registry.service.discovery;
+
+import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.Response;
+import com.ecwid.consul.v1.health.model.HealthService;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import tech.jhipster.registry.config.ApplicationProperties;
+
+@Service
+@ConditionalOnProperty(name = "application.discovery.backend", havingValue = "consul")
+public class ConsulDiscoveryService implements DiscoveryService {
+
+    private final Logger log = LoggerFactory.getLogger(ConsulDiscoveryService.class);
+
+    private final ApplicationProperties applicationProperties;
+
+    private final ConsulClient consulClient;
+
+    public ConsulDiscoveryService(ApplicationProperties applicationProperties) {
+        this.applicationProperties = applicationProperties;
+        String host = applicationProperties.getConsul().getHost();
+        int port = applicationProperties.getConsul().getPort();
+        this.consulClient = new ConsulClient(host, port);
+        log.info("Consul discovery service initialized with {}:{}", host, port);
+    }
+
+    @Override
+    public String getBackendType() {
+        return "consul";
+    }
+
+    @Override
+    public List<Map<String, Object>> getApplications() {
+        List<Map<String, Object>> apps = new ArrayList<>();
+        try {
+            Response<Map<String, List<String>>> services = consulClient.getAgentServices();
+            Map<String, List<String>> serviceMap = services.getValue();
+            for (Map.Entry<String, List<String>> entry : serviceMap.entrySet()) {
+                Map<String, Object> appData = new LinkedHashMap<>();
+                appData.put("name", entry.getKey());
+                List<Map<String, Object>> instances = new ArrayList<>();
+                Response<List<HealthService>> healthServices = consulClient.getHealthServices(
+                    entry.getKey(),
+                    true,
+                    null
+                );
+                for (HealthService healthService : healthServices.getValue()) {
+                    Map<String, Object> instance = new HashMap<>();
+                    HealthService.Service service = healthService.getService();
+                    instance.put("instanceId", service.getId());
+                    instance.put("homePageUrl", buildHomePageUrl(service));
+                    instance.put("status", healthService.getChecks().stream().allMatch(c -> "passing".equals(c.getStatus())) ? "UP" : "DOWN");
+                    instance.put("metadata", service.getMeta());
+                    instances.add(instance);
+                }
+                appData.put("instances", instances);
+                apps.add(appData);
+            }
+        } catch (Exception e) {
+            log.error("Failed to fetch applications from Consul: {}", e.getMessage());
+        }
+        return apps;
+    }
+
+    @Override
+    public Map<String, Object> getStatus() {
+        Map<String, Object> stats = new HashMap<>();
+        try {
+            Response<Map<String, String>> self = consulClient.getAgentSelf();
+            Map<String, String> selfInfo = self.getValue();
+            stats.put("backend", "consul");
+            stats.putAll(selfInfo);
+        } catch (Exception e) {
+            log.error("Failed to fetch Consul status: {}", e.getMessage());
+            stats.put("error", e.getMessage());
+        }
+        return stats;
+    }
+
+    @Override
+    public List<String> getReplicas() {
+        List<String> replicas = new ArrayList<>();
+        try {
+            Response<List<Map<String, Object>>> peers = consulClient.getStatusPeers();
+            for (Map<String, Object> peer : peers.getValue()) {
+                replicas.add(peer.toString());
+            }
+        } catch (Exception e) {
+            log.error("Failed to fetch Consul peers: {}", e.getMessage());
+        }
+        return replicas;
+    }
+
+    @Override
+    public Map<String, Map<Long, String>> getLastN() {
+        return new HashMap<>();
+    }
+
+    private String buildHomePageUrl(HealthService.Service service) {
+        String address = service.getAddress();
+        int port = service.getPort();
+        if (address != null && port > 0) {
+            return "http://" + address + ":" + port;
+        }
+        return "";
+    }
+}

--- a/src/main/java/tech/jhipster/registry/service/discovery/DiscoveryService.java
+++ b/src/main/java/tech/jhipster/registry/service/discovery/DiscoveryService.java
@@ -1,0 +1,17 @@
+package tech.jhipster.registry.service.discovery;
+
+import java.util.List;
+import java.util.Map;
+
+public interface DiscoveryService {
+
+    String getBackendType();
+
+    List<Map<String, Object>> getApplications();
+
+    Map<String, Object> getStatus();
+
+    List<String> getReplicas();
+
+    Map<String, Map<Long, String>> getLastN();
+}

--- a/src/main/java/tech/jhipster/registry/service/discovery/EurekaDiscoveryService.java
+++ b/src/main/java/tech/jhipster/registry/service/discovery/EurekaDiscoveryService.java
@@ -1,0 +1,138 @@
+package tech.jhipster.registry.service.discovery;
+
+import static java.util.stream.Collectors.toMap;
+
+import com.netflix.appinfo.InstanceInfo;
+import com.netflix.discovery.shared.Application;
+import com.netflix.discovery.shared.Pair;
+import com.netflix.eureka.EurekaServerContext;
+import com.netflix.eureka.EurekaServerContextHolder;
+import com.netflix.eureka.registry.PeerAwareInstanceRegistry;
+import com.netflix.eureka.registry.PeerAwareInstanceRegistryImpl;
+import com.netflix.eureka.resources.StatusResource;
+import com.netflix.eureka.util.StatusInfo;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import tech.jhipster.registry.config.ApplicationProperties;
+
+@Service
+@ConditionalOnProperty(name = "application.discovery.backend", havingValue = "eureka", matchIfMissing = true)
+public class EurekaDiscoveryService implements DiscoveryService {
+
+    private final Logger log = LoggerFactory.getLogger(EurekaDiscoveryService.class);
+
+    private final ApplicationProperties applicationProperties;
+
+    public EurekaDiscoveryService(ApplicationProperties applicationProperties) {
+        this.applicationProperties = applicationProperties;
+    }
+
+    @Override
+    public String getBackendType() {
+        return "eureka";
+    }
+
+    @Override
+    public List<Map<String, Object>> getApplications() {
+        List<Application> sortedApplications = getRegistry().getSortedApplications();
+        ArrayList<Map<String, Object>> apps = new ArrayList<>();
+        for (Application app : sortedApplications) {
+            LinkedHashMap<String, Object> appData = new LinkedHashMap<>();
+            apps.add(appData);
+            appData.put("name", app.getName());
+            List<Map<String, Object>> instances = new ArrayList<>();
+            for (InstanceInfo info : app.getInstances()) {
+                Map<String, Object> instance = new HashMap<>();
+                instance.put("instanceId", info.getInstanceId());
+                instance.put("homePageUrl", info.getHomePageUrl());
+                instance.put("healthCheckUrl", info.getHealthCheckUrl());
+                instance.put("statusPageUrl", info.getStatusPageUrl());
+                instance.put("status", info.getStatus().name());
+                instance.put("metadata", info.getMetadata());
+                instances.add(instance);
+            }
+            appData.put("instances", instances);
+        }
+        return apps;
+    }
+
+    @Override
+    public Map<String, Object> getStatus() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put("time", new Date());
+        stats.put("currentTime", StatusResource.getCurrentTimeAsString());
+        stats.put("upTime", StatusInfo.getUpTime());
+        stats.put("environment", applicationProperties.getEureka().getEnvironment());
+        stats.put("datacenter", applicationProperties.getEureka().getDatacenter());
+        PeerAwareInstanceRegistry registry = getRegistry();
+        stats.put("isBelowRenewThreshold", registry.isBelowRenewThresold() == 1);
+        populateInstanceInfo(stats);
+        return stats;
+    }
+
+    @Override
+    public List<String> getReplicas() {
+        List<String> replicas = new ArrayList<>();
+        getServerContext()
+            .getPeerEurekaNodes()
+            .getPeerNodesView()
+            .forEach(node -> {
+                try {
+                    URI uri = new URI(node.getServiceUrl());
+                    replicas.add(uri.getHost() + ":" + uri.getPort());
+                } catch (URISyntaxException e) {
+                    log.warn("Could not parse peer Eureka node URL: {}", e.getMessage());
+                }
+            });
+        return replicas;
+    }
+
+    @Override
+    public Map<String, Map<Long, String>> getLastN() {
+        Map<String, Map<Long, String>> lastn = new HashMap<>();
+        PeerAwareInstanceRegistryImpl registry = (PeerAwareInstanceRegistryImpl) getRegistry();
+        Map<Long, String> canceledMap = registry.getLastNCanceledInstances().stream().collect(toMap(Pair::first, Pair::second));
+        lastn.put("canceled", canceledMap);
+        Map<Long, String> registeredMap = registry.getLastNRegisteredInstances().stream().collect(toMap(Pair::first, Pair::second));
+        lastn.put("registered", registeredMap);
+        return lastn;
+    }
+
+    private void populateInstanceInfo(Map<String, Object> model) {
+        StatusInfo statusInfo;
+        try {
+            statusInfo = new StatusResource().getStatusInfo();
+        } catch (Exception e) {
+            log.error(e.getMessage());
+            statusInfo = StatusInfo.Builder.newBuilder().isHealthy(false).build();
+        }
+        if (statusInfo != null && statusInfo.getGeneralStats() != null) {
+            model.put("generalStats", statusInfo.getGeneralStats());
+        }
+        if (statusInfo != null && statusInfo.getInstanceInfo() != null) {
+            InstanceInfo instanceInfo = statusInfo.getInstanceInfo();
+            Map<String, String> instanceMap = new HashMap<>();
+            instanceMap.put("ipAddr", instanceInfo.getIPAddr());
+            instanceMap.put("status", instanceInfo.getStatus().toString());
+            model.put("instanceInfo", instanceMap);
+        }
+    }
+
+    private PeerAwareInstanceRegistry getRegistry() {
+        return getServerContext().getRegistry();
+    }
+
+    private EurekaServerContext getServerContext() {
+        return EurekaServerContextHolder.getInstance().getServerContext();
+    }
+}

--- a/src/main/java/tech/jhipster/registry/service/discovery/KubernetesDiscoveryService.java
+++ b/src/main/java/tech/jhipster/registry/service/discovery/KubernetesDiscoveryService.java
@@ -1,0 +1,116 @@
+package tech.jhipster.registry.service.discovery;
+
+import io.kubernetes.client.openapi.ApiClient;
+import io.kubernetes.client.openapi.ApiException;
+import io.kubernetes.client.openapi.Configuration;
+import io.kubernetes.client.openapi.apis.CoreV1Api;
+import io.kubernetes.client.openapi.models.V1Service;
+import io.kubernetes.client.openapi.models.V1ServiceList;
+import io.kubernetes.client.openapi.models.V1Endpoints;
+import io.kubernetes.client.openapi.models.V1EndpointsList;
+import io.kubernetes.client.util.ClientBuilder;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import tech.jhipster.registry.config.ApplicationProperties;
+
+@Service
+@ConditionalOnProperty(name = "application.discovery.backend", havingValue = "kubernetes")
+public class KubernetesDiscoveryService implements DiscoveryService {
+
+    private final Logger log = LoggerFactory.getLogger(KubernetesDiscoveryService.class);
+
+    private final ApplicationProperties applicationProperties;
+
+    private final CoreV1Api api;
+
+    public KubernetesDiscoveryService(ApplicationProperties applicationProperties) throws IOException {
+        this.applicationProperties = applicationProperties;
+        ApiClient client = ClientBuilder.cluster().build();
+        Configuration.setDefaultApiClient(client);
+        this.api = new CoreV1Api();
+        log.info("Kubernetes discovery service initialized in namespace: {}", applicationProperties.getKubernetes().getNamespace());
+    }
+
+    @Override
+    public String getBackendType() {
+        return "kubernetes";
+    }
+
+    @Override
+    public List<Map<String, Object>> getApplications() {
+        List<Map<String, Object>> apps = new ArrayList<>();
+        String namespace = applicationProperties.getKubernetes().getNamespace();
+        try {
+            V1ServiceList services = api.listNamespacedService(namespace, null, null, null, null, null, null, null, null, null, null);
+            for (V1Service svc : services.getItems()) {
+                Map<String, Object> appData = new LinkedHashMap<>();
+                appData.put("name", svc.getMetadata().getName());
+                List<Map<String, Object>> instances = new ArrayList<>();
+                try {
+                    V1EndpointsList endpoints = api.listNamespacedEndpoints(
+                        namespace,
+                        null, null, null, null,
+                        "metadata.name=" + svc.getMetadata().getName(),
+                        null, null, null, null, null
+                    );
+                    for (V1Endpoints ep : endpoints.getItems()) {
+                        if (ep.getSubsets() != null) {
+                            for (var subset : ep.getSubsets()) {
+                                if (subset.getAddresses() != null) {
+                                    for (var addr : subset.getAddresses()) {
+                                        Map<String, Object> instance = new HashMap<>();
+                                        instance.put("instanceId", addr.getIp());
+                                        instance.put("status", "UP");
+                                        instance.put("homePageUrl", buildHomePageUrl(addr.getIp(), svc));
+                                        instances.add(instance);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } catch (ApiException e) {
+                    log.warn("Failed to fetch endpoints for service {}: {}", svc.getMetadata().getName(), e.getMessage());
+                }
+                appData.put("instances", instances);
+                apps.add(appData);
+            }
+        } catch (ApiException e) {
+            log.error("Failed to fetch Kubernetes services: {}", e.getMessage());
+        }
+        return apps;
+    }
+
+    @Override
+    public Map<String, Object> getStatus() {
+        Map<String, Object> stats = new HashMap<>();
+        stats.put("backend", "kubernetes");
+        stats.put("namespace", applicationProperties.getKubernetes().getNamespace());
+        return stats;
+    }
+
+    @Override
+    public List<String> getReplicas() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public Map<String, Map<Long, String>> getLastN() {
+        return new HashMap<>();
+    }
+
+    private String buildHomePageUrl(String ip, V1Service svc) {
+        if (svc.getSpec() != null && svc.getSpec().getPorts() != null && !svc.getSpec().getPorts().isEmpty()) {
+            int port = svc.getSpec().getPorts().get(0).getPort();
+            return "http://" + ip + ":" + port;
+        }
+        return "http://" + ip;
+    }
+}

--- a/src/main/java/tech/jhipster/registry/web/rest/DiscoveryResource.java
+++ b/src/main/java/tech/jhipster/registry/web/rest/DiscoveryResource.java
@@ -1,0 +1,55 @@
+package tech.jhipster.registry.web.rest;
+
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tech.jhipster.registry.service.discovery.DiscoveryService;
+import tech.jhipster.registry.web.rest.vm.EurekaVM;
+
+@RestController
+@RequestMapping("/api")
+public class DiscoveryResource {
+
+    private final Logger log = LoggerFactory.getLogger(DiscoveryResource.class);
+
+    private final DiscoveryService discoveryService;
+
+    public DiscoveryResource(DiscoveryService discoveryService) {
+        this.discoveryService = discoveryService;
+    }
+
+    @GetMapping("/discovery/applications")
+    public ResponseEntity<EurekaVM> applications() {
+        EurekaVM vm = new EurekaVM();
+        vm.setApplications(discoveryService.getApplications());
+        return new ResponseEntity<>(vm, HttpStatus.OK);
+    }
+
+    @GetMapping("/discovery/status")
+    public ResponseEntity<EurekaVM> status() {
+        EurekaVM vm = new EurekaVM();
+        vm.setStatus(discoveryService.getStatus());
+        return new ResponseEntity<>(vm, HttpStatus.OK);
+    }
+
+    @GetMapping("/discovery/replicas")
+    public ResponseEntity<List<String>> replicas() {
+        return new ResponseEntity<>(discoveryService.getReplicas(), HttpStatus.OK);
+    }
+
+    @GetMapping("/discovery/lastn")
+    public ResponseEntity<Map<String, Map<Long, String>>> lastn() {
+        return new ResponseEntity<>(discoveryService.getLastN(), HttpStatus.OK);
+    }
+
+    @GetMapping("/discovery/backend")
+    public ResponseEntity<Map<String, String>> backend() {
+        return new ResponseEntity<>(Map.of("backend", discoveryService.getBackendType()), HttpStatus.OK);
+    }
+}

--- a/src/main/java/tech/jhipster/registry/web/rest/EurekaResource.java
+++ b/src/main/java/tech/jhipster/registry/web/rest/EurekaResource.java
@@ -1,22 +1,5 @@
 package tech.jhipster.registry.web.rest;
 
-import static java.util.stream.Collectors.toMap;
-
-import com.netflix.appinfo.InstanceInfo;
-import com.netflix.discovery.shared.Application;
-import com.netflix.discovery.shared.Pair;
-import com.netflix.eureka.EurekaServerContext;
-import com.netflix.eureka.EurekaServerContextHolder;
-import com.netflix.eureka.registry.PeerAwareInstanceRegistry;
-import com.netflix.eureka.registry.PeerAwareInstanceRegistryImpl;
-import com.netflix.eureka.resources.StatusResource;
-import com.netflix.eureka.util.StatusInfo;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -26,143 +9,42 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import tech.jhipster.registry.config.ApplicationProperties;
+import tech.jhipster.registry.service.discovery.DiscoveryService;
 import tech.jhipster.registry.web.rest.vm.EurekaVM;
 
-/**
- * Controller for viewing Eureka data.
- */
 @RestController
 @RequestMapping("/api")
 public class EurekaResource {
 
     private final Logger log = LoggerFactory.getLogger(EurekaResource.class);
 
-    private final ApplicationProperties applicationProperties;
+    private final DiscoveryService discoveryService;
 
-    public EurekaResource(ApplicationProperties applicationProperties) {
-        this.applicationProperties = applicationProperties;
+    public EurekaResource(DiscoveryService discoveryService) {
+        this.discoveryService = discoveryService;
     }
 
-    /**
-     * GET  /eureka/applications : get Eureka applications information
-     */
     @GetMapping("/eureka/applications")
     public ResponseEntity<EurekaVM> eureka() {
         EurekaVM eurekaVM = new EurekaVM();
-        eurekaVM.setApplications(getApplications());
+        eurekaVM.setApplications(discoveryService.getApplications());
         return new ResponseEntity<>(eurekaVM, HttpStatus.OK);
     }
 
-    private List<Map<String, Object>> getApplications() {
-        List<Application> sortedApplications = getRegistry().getSortedApplications();
-        ArrayList<Map<String, Object>> apps = new ArrayList<>();
-        for (Application app : sortedApplications) {
-            LinkedHashMap<String, Object> appData = new LinkedHashMap<>();
-            apps.add(appData);
-            appData.put("name", app.getName());
-            List<Map<String, Object>> instances = new ArrayList<>();
-            for (InstanceInfo info : app.getInstances()) {
-                Map<String, Object> instance = new HashMap<>();
-                instance.put("instanceId", info.getInstanceId());
-                instance.put("homePageUrl", info.getHomePageUrl());
-                instance.put("healthCheckUrl", info.getHealthCheckUrl());
-                instance.put("statusPageUrl", info.getStatusPageUrl());
-                instance.put("status", info.getStatus().name());
-                instance.put("metadata", info.getMetadata());
-                instances.add(instance);
-            }
-            appData.put("instances", instances);
-        }
-        return apps;
-    }
-
-    /**
-     * GET  /eureka/lastn : get Eureka registrations
-     */
     @GetMapping("/eureka/lastn")
     public ResponseEntity<Map<String, Map<Long, String>>> lastn() {
-        Map<String, Map<Long, String>> lastn = new HashMap<>();
-        PeerAwareInstanceRegistryImpl registry = (PeerAwareInstanceRegistryImpl) getRegistry();
-        Map<Long, String> canceledMap = registry.getLastNCanceledInstances().stream().collect(toMap(Pair::first, Pair::second));
-        lastn.put("canceled", canceledMap);
-        Map<Long, String> registeredMap = registry.getLastNRegisteredInstances().stream().collect(toMap(Pair::first, Pair::second));
-        lastn.put("registered", registeredMap);
-        return new ResponseEntity<>(lastn, HttpStatus.OK);
+        return new ResponseEntity<>(discoveryService.getLastN(), HttpStatus.OK);
     }
 
-    /**
-     * GET  /eureka/replicas : get Eureka replicas
-     */
     @GetMapping("/eureka/replicas")
     public ResponseEntity<List<String>> replicas() {
-        List<String> replicas = new ArrayList<>();
-        getServerContext()
-            .getPeerEurekaNodes()
-            .getPeerNodesView()
-            .forEach(node -> {
-                try {
-                    // The URL is parsed in order to remove login/password information
-                    URI uri = new URI(node.getServiceUrl());
-                    replicas.add(uri.getHost() + ":" + uri.getPort());
-                } catch (URISyntaxException e) {
-                    log.warn("Could not parse peer Eureka node URL: {}", e.getMessage());
-                }
-            });
-
-        return new ResponseEntity<>(replicas, HttpStatus.OK);
+        return new ResponseEntity<>(discoveryService.getReplicas(), HttpStatus.OK);
     }
 
-    /**
-     * GET  /eureka/status : get Eureka status
-     */
     @GetMapping("/eureka/status")
     public ResponseEntity<EurekaVM> eurekaStatus() {
         EurekaVM eurekaVM = new EurekaVM();
-        eurekaVM.setStatus(getEurekaStatus());
+        eurekaVM.setStatus(discoveryService.getStatus());
         return new ResponseEntity<>(eurekaVM, HttpStatus.OK);
-    }
-
-    private Map<String, Object> getEurekaStatus() {
-        Map<String, Object> stats = new HashMap<>();
-        stats.put("time", new Date());
-        stats.put("currentTime", StatusResource.getCurrentTimeAsString());
-        stats.put("upTime", StatusInfo.getUpTime());
-        stats.put("environment", applicationProperties.getEureka().getEnvironment());
-        stats.put("datacenter", applicationProperties.getEureka().getDatacenter());
-        PeerAwareInstanceRegistry registry = getRegistry();
-
-        stats.put("isBelowRenewThreshold", registry.isBelowRenewThresold() == 1);
-        populateInstanceInfo(stats);
-
-        return stats;
-    }
-
-    private void populateInstanceInfo(Map<String, Object> model) {
-        StatusInfo statusInfo;
-        try {
-            statusInfo = new StatusResource().getStatusInfo();
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            statusInfo = StatusInfo.Builder.newBuilder().isHealthy(false).build();
-        }
-        if (statusInfo != null && statusInfo.getGeneralStats() != null) {
-            model.put("generalStats", statusInfo.getGeneralStats());
-        }
-        if (statusInfo != null && statusInfo.getInstanceInfo() != null) {
-            InstanceInfo instanceInfo = statusInfo.getInstanceInfo();
-            Map<String, String> instanceMap = new HashMap<>();
-            instanceMap.put("ipAddr", instanceInfo.getIPAddr());
-            instanceMap.put("status", instanceInfo.getStatus().toString());
-            model.put("instanceInfo", instanceMap);
-        }
-    }
-
-    private PeerAwareInstanceRegistry getRegistry() {
-        return getServerContext().getRegistry();
-    }
-
-    private EurekaServerContext getServerContext() {
-        return EurekaServerContextHolder.getInstance().getServerContext();
     }
 }

--- a/src/main/resources/config/application-consul.yml
+++ b/src/main/resources/config/application-consul.yml
@@ -1,0 +1,16 @@
+# Consul Discovery Configuration
+application:
+  discovery:
+    backend: consul
+  consul:
+    host: ${CONSUL_HOST:localhost}
+    port: ${CONSUL_PORT:8500}
+
+spring:
+  cloud:
+    consul:
+      discovery:
+        enabled: true
+        register: false
+      host: ${CONSUL_HOST:localhost}
+      port: ${CONSUL_PORT:8500}

--- a/src/main/resources/config/application-kubernetes.yml
+++ b/src/main/resources/config/application-kubernetes.yml
@@ -1,0 +1,13 @@
+# Kubernetes Discovery Configuration
+application:
+  discovery:
+    backend: kubernetes
+  kubernetes:
+    namespace: ${KUBERNETES_NAMESPACE:default}
+
+spring:
+  cloud:
+    kubernetes:
+      discovery:
+        enabled: true
+        register: false


### PR DESCRIPTION
## Description

Implements support for additional discovery and configuration systems (Consul & Kubernetes) as requested in #320.

### Changes

1. **DiscoveryService interface** - Abstract interface for discovery backends
2. **EurekaDiscoveryService** - Wraps existing Eureka logic (default, backward compatible)
3. **ConsulDiscoveryService** - New Consul backend using HTTP API
4. **KubernetesDiscoveryService** - New Kubernetes backend using K8s API
5. **DiscoveryResource** - Unified REST API for all backends
6. **EurekaResource** - Refactored to delegate to DiscoveryService
7. **EurekaServerConditionalConfiguration** - Eureka only loads when selected
8. **ApplicationProperties** - Added Consul, Kubernetes, Discovery config
9. **Spring profiles** - `application-consul.yml` and `application-kubernetes.yml`
10. **Documentation** - DISCOVERY_BACKEND.md with setup instructions

### Key Design Decisions

- **Backward compatible**: Eureka remains the default backend (matchIfMissing = true)
- **Conditional loading**: Each backend only loads when selected via `application.discovery.backend`
- **Unified API**: New `/api/discovery/*` endpoints work with any backend
- **Legacy support**: Old `/api/eureka/*` endpoints still work
- **Spring profiles**: Easy switching with `--spring.profiles.active=consul|kubernetes`

### Configuration

```yaml
# application.yml
application:
  discovery:
    backend: eureka  # or consul, kubernetes
  consul:
    host: localhost
    port: 8500
  kubernetes:
    namespace: default
```

Closes #320
